### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/lib/data/compression_options_data.c
+++ b/lib/data/compression_options_data.c
@@ -35,7 +35,11 @@
 
 #include "../../include/sqsh_data_private.h"
 
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 struct SQSH_UNALIGNED SqshDataCompressionOptionsGzip {
 	uint32_t compression_level;

--- a/lib/data/directory_data.c
+++ b/lib/data/directory_data.c
@@ -35,7 +35,11 @@
 
 #include "../../include/sqsh_data_private.h"
 
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 struct SQSH_UNALIGNED SqshDataDirectoryEntry {
 	uint16_t offset;

--- a/lib/data/fragment_data.c
+++ b/lib/data/fragment_data.c
@@ -35,7 +35,11 @@
 
 #include "../../include/sqsh_data_private.h"
 
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 struct SQSH_UNALIGNED SqshDataFragment {
 	uint64_t start;

--- a/lib/data/inode_data.c
+++ b/lib/data/inode_data.c
@@ -35,7 +35,11 @@
 
 #include "../../include/sqsh_data_private.h"
 
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 struct SQSH_UNALIGNED SqshDataInodeDirectoryIndex {
 	uint32_t index;

--- a/lib/data/metablock_data.c
+++ b/lib/data/metablock_data.c
@@ -35,7 +35,11 @@
 
 #include "../../include/sqsh_data_private.h"
 
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 struct SQSH_UNALIGNED SqshDataMetablock {
 	uint16_t header;

--- a/lib/data/superblock_data.c
+++ b/lib/data/superblock_data.c
@@ -35,7 +35,11 @@
 
 #include "../../include/sqsh_data_private.h"
 
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 struct SQSH_UNALIGNED SqshDataSuperblock {
 	uint32_t magic;

--- a/lib/data/xattr_data.c
+++ b/lib/data/xattr_data.c
@@ -35,7 +35,12 @@
 
 #include "../../include/sqsh_data_private.h"
 
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
+
 #include <string.h>
 
 struct SQSH_UNALIGNED SqshDataXattrKey {


### PR DESCRIPTION
This fixes compilation on FreeBSD:

```
#if defined(__FreeBSD__)
#include <sys/endian.h>
#else
#include <endian.h>
#endif
```