### PR TITLE
subproject: update meson wrapfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,11 +56,6 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
-### Meson ###
-# subproject directories
-/subprojects/*
-!/subprojects/*.wrap
-
 # Meson Directories
 meson-logs
 meson-private

--- a/subprojects/cextras.wrap
+++ b/subprojects/cextras.wrap
@@ -1,7 +1,9 @@
-[wrap-git]
-url=https://github.com/Gottox/cextras.git
-revision=9a39123923ccefd5939a30fb163c3df0e823db97
-depth=1
+[wrap-file]
+directory = cextras-9a39123923ccefd5939a30fb163c3df0e823db97
+
+source_url = https://github.com/Gottox/cextras/archive/9a39123923ccefd5939a30fb163c3df0e823db97.tar.gz
+source_filename = cextras-9a39123923ccefd5939a30fb163c3df0e823db97.tar.gz
+source_hash = 8466e13d59da79ac485614377a8550aa573beb9989c8a3d0925d290025d01c30
 
 [provide]
 cextras=cextras_dep


### PR DESCRIPTION
This updates the meson wrapfile for cextras to point to the right directory. This is needed because the meson wrapfile was not updated when the cextras subproject was included in the tree.