### PR TITLE
directory_iterator: consistency check on open

### DIFF
--- a/test/directory/directory_iterator.c
+++ b/test/directory/directory_iterator.c
@@ -207,9 +207,55 @@ iter_invalid_file_type(void) {
 	sqsh__archive_cleanup(&archive);
 }
 
+static void
+iter_inconsistent_file_type(void) {
+	int rv;
+	struct SqshArchive archive = {0};
+	uint8_t payload[] = {
+			/* clang-format off */
+			SQSH_HEADER,
+			/* inode */
+			[INODE_TABLE_OFFSET] = METABLOCK_HEADER(0, 1024),
+			INODE_HEADER(1, 0, 0, 0, 0, 1),
+			INODE_BASIC_DIR(0, 1024, 0, 0),
+			[INODE_TABLE_OFFSET+2+128] =
+			INODE_HEADER(3, 0, 0, 0, 0, 2),
+			INODE_BASIC_SYMLINK(3),
+			't', 'g', 't',
+			[DIRECTORY_TABLE_OFFSET] = METABLOCK_HEADER(0, 128),
+			DIRECTORY_HEADER(2, 0, 0),
+			DIRECTORY_ENTRY(128, 2, 1, 1),
+			'1',
+			[FRAGMENT_TABLE_OFFSET] = 0,
+			/* clang-format on */
+	};
+	mk_stub(&archive, payload, sizeof(payload));
+
+	struct SqshFile file = {0};
+	rv = sqsh__file_init(&file, &archive, 0);
+	assert(rv == 0);
+
+	struct SqshDirectoryIterator *iter =
+			sqsh_directory_iterator_new(&file, &rv);
+	assert(rv == 0);
+
+	bool has_next = sqsh_directory_iterator_next(iter, &rv);
+	assert(rv == 0);
+	assert(has_next == true);
+
+	struct SqshFile *entry_file = sqsh_directory_iterator_open_file(iter, &rv);
+	assert(rv == -SQSH_ERROR_CORRUPTED_DIRECTORY_ENTRY);
+	assert(entry_file == NULL);
+
+	sqsh_directory_iterator_free(iter);
+	sqsh__file_cleanup(&file);
+	sqsh__archive_cleanup(&archive);
+}
+
 DECLARE_TESTS
 TEST(iter_two_files)
 TEST(iter_invalid_file_name_with_slash)
 TEST(iter_invalid_file_name_with_0)
 TEST(iter_invalid_file_type)
+TEST(iter_inconsistent_file_type)
 END_TESTS


### PR DESCRIPTION
when opening an SqshFile from a SqshDirectoryIterator, check that the information safed in the directory iterator are consistent with the information in the inode of the file.

This commit contains the fix and also a test case that reproduces the bug.