### PR TITLE
.github: add codecov.yaml configuration

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch:
+      default:
+        threshold: 30%


### PR DESCRIPTION
This change adds a threshold to the codecov configuration. This is needed to let the CI not fail when small changes are made.