### PR TITLE
meson.build: add version constraint to libcurl

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,5 +1,4 @@
 libsqsh_sources = files(
-    'reader/reader.c',
     'archive/archive.c',
     'archive/compression_options.c',
     'archive/inode_map.c',
@@ -38,6 +37,7 @@ libsqsh_sources = files(
     'mapper/static_mapper.c',
     'metablock/metablock_iterator.c',
     'metablock/metablock_reader.c',
+    'reader/reader.c',
     'table/export_table.c',
     'table/fragment_table.c',
     'table/id_table.c',

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,11 @@ project(
 )
 
 threads_dep = dependency('threads', required: get_option('threads'))
-curl_dep = dependency('libcurl', required: get_option('curl'))
+curl_dep = dependency(
+    'libcurl',
+    version: '>=7.83.0',
+    required: get_option('curl'),
+)
 fuse3_dep = dependency(
     'fuse3',
     required: get_option('fuse'),


### PR DESCRIPTION
Up to now older versions of curl would fail to build as `curl_easy_header` was not defined. This change adds a version constraint to the dependency to make sure curl is only used if the version is new enough.