### PR TITLE
test: add in depth tests for compression options

### DIFF
--- a/test/archive/compression_options.c
+++ b/test/archive/compression_options.c
@@ -38,8 +38,21 @@
 #include "../../include/sqsh_archive_private.h"
 #include "../../lib/utils/utils.h"
 
+#define GZIP_OPTIONS(level, winsize, strategy) \
+	UINT32_BYTES(level), UINT16_BYTES(winsize), UINT16_BYTES(strategy)
+#define XZ_OPTIONS(dictionary_size, filters) \
+	UINT32_BYTES(dictionary_size), UINT32_BYTES(filters)
+#define LZ4_OPTIONS(version, flags) UINT32_BYTES(version), UINT32_BYTES(flags)
+#define ZSTD_OPTIONS(level) UINT32_BYTES(level)
+#define LZO_OPTIONS(algorithm, level) \
+	UINT32_BYTES(algorithm), UINT32_BYTES(level)
+
+// Make sure, that lzo compression is not NULL, otherwise libsqsh will refuse
+// to init the archive.
+const struct SqshExtractorImpl *const sqsh__impl_lzo = (void *)0x1;
+
 static void
-load_compression_options(void) {
+load_compression_options_gzip(void) {
 	int rv;
 	struct SqshArchive archive = {0};
 	uint8_t payload[8192] = {
@@ -47,6 +60,7 @@ load_compression_options(void) {
 			/* inode */
 			METABLOCK_HEADER(0, CHUNK_SIZE(GZIP_OPTIONS(0, 0, 0))),
 			GZIP_OPTIONS(123, 456, 789)};
+	payload[20] = 1;
 	mk_stub(&archive, payload, sizeof(payload));
 
 	struct SqshCompressionOptions *options =
@@ -54,14 +68,192 @@ load_compression_options(void) {
 	assert(rv == 0);
 	assert(options != NULL);
 
+	assert(sqsh_compression_options_size(options) == 8);
+
 	assert(sqsh_compression_options_gzip_compression_level(options) == 123);
 	assert(sqsh_compression_options_gzip_window_size(options) == 456);
 	assert(sqsh_compression_options_gzip_strategies(options) == 789);
 
+	assert(sqsh_compression_options_xz_dictionary_size(options) == UINT32_MAX);
+	assert(sqsh_compression_options_xz_filters(options) == UINT32_MAX);
+
+	assert(sqsh_compression_options_lz4_version(options) == UINT32_MAX);
+	assert(sqsh_compression_options_lz4_flags(options) == UINT32_MAX);
+
+	assert(sqsh_compression_options_zstd_compression_level(options) ==
+		   UINT32_MAX);
+
+	assert(sqsh_compression_options_lzo_algorithm(options) == UINT32_MAX);
+	assert(sqsh_compression_options_lzo_compression_level(options) ==
+		   UINT32_MAX);
+	sqsh_compression_options_free(options);
+	sqsh__archive_cleanup(&archive);
+}
+
+static void
+load_compression_options_xz(void) {
+	int rv;
+	struct SqshArchive archive = {0};
+	uint8_t payload[8192] = {
+			SQSH_HEADER,
+			/* inode */
+			METABLOCK_HEADER(0, CHUNK_SIZE(XZ_OPTIONS(0, 0))),
+			XZ_OPTIONS(123, 456)};
+	payload[20] = 4;
+	mk_stub(&archive, payload, sizeof(payload));
+
+	struct SqshCompressionOptions *options =
+			sqsh_compression_options_new(&archive, &rv);
+	assert(rv == 0);
+	assert(options != NULL);
+
+	assert(sqsh_compression_options_size(options) == 8);
+
+	assert(sqsh_compression_options_gzip_compression_level(options) ==
+		   UINT32_MAX);
+	assert(sqsh_compression_options_gzip_window_size(options) == UINT16_MAX);
+	assert(sqsh_compression_options_gzip_strategies(options) == UINT16_MAX);
+
+	assert(sqsh_compression_options_xz_dictionary_size(options) == 123);
+	assert(sqsh_compression_options_xz_filters(options) == 456);
+
+	assert(sqsh_compression_options_lz4_version(options) == UINT32_MAX);
+	assert(sqsh_compression_options_lz4_flags(options) == UINT32_MAX);
+
+	assert(sqsh_compression_options_zstd_compression_level(options) ==
+		   UINT32_MAX);
+
+	assert(sqsh_compression_options_lzo_algorithm(options) == UINT32_MAX);
+	assert(sqsh_compression_options_lzo_compression_level(options) ==
+		   UINT32_MAX);
+	sqsh_compression_options_free(options);
+	sqsh__archive_cleanup(&archive);
+}
+
+static void
+load_compression_options_lz4(void) {
+	int rv;
+	struct SqshArchive archive = {0};
+	uint8_t payload[8192] = {
+			SQSH_HEADER,
+			/* inode */
+			METABLOCK_HEADER(0, CHUNK_SIZE(LZ4_OPTIONS(0, 0))),
+			LZ4_OPTIONS(123, 456)};
+	payload[20] = 5;
+	mk_stub(&archive, payload, sizeof(payload));
+
+	struct SqshCompressionOptions *options =
+			sqsh_compression_options_new(&archive, &rv);
+	assert(rv == 0);
+	assert(options != NULL);
+
+	assert(sqsh_compression_options_size(options) == 8);
+
+	assert(sqsh_compression_options_gzip_compression_level(options) ==
+		   UINT32_MAX);
+	assert(sqsh_compression_options_gzip_window_size(options) == UINT16_MAX);
+	assert(sqsh_compression_options_gzip_strategies(options) == UINT16_MAX);
+
+	assert(sqsh_compression_options_xz_dictionary_size(options) == UINT32_MAX);
+	assert(sqsh_compression_options_xz_filters(options) == UINT32_MAX);
+
+	assert(sqsh_compression_options_lz4_version(options) == 123);
+	assert(sqsh_compression_options_lz4_flags(options) == 456);
+
+	assert(sqsh_compression_options_zstd_compression_level(options) ==
+		   UINT32_MAX);
+
+	assert(sqsh_compression_options_lzo_algorithm(options) == UINT32_MAX);
+	assert(sqsh_compression_options_lzo_compression_level(options) ==
+		   UINT32_MAX);
+	sqsh_compression_options_free(options);
+	sqsh__archive_cleanup(&archive);
+}
+
+static void
+load_compression_options_zstd(void) {
+	int rv;
+	struct SqshArchive archive = {0};
+	uint8_t payload[8192] = {
+			SQSH_HEADER,
+			/* inode */
+			METABLOCK_HEADER(0, CHUNK_SIZE(ZSTD_OPTIONS(0))),
+			ZSTD_OPTIONS(123)};
+	payload[20] = 6;
+	mk_stub(&archive, payload, sizeof(payload));
+
+	struct SqshCompressionOptions *options =
+			sqsh_compression_options_new(&archive, &rv);
+	assert(rv == 0);
+	assert(options != NULL);
+
+	assert(sqsh_compression_options_size(options) == 4);
+
+	assert(sqsh_compression_options_gzip_compression_level(options) ==
+		   UINT32_MAX);
+	assert(sqsh_compression_options_gzip_window_size(options) == UINT16_MAX);
+	assert(sqsh_compression_options_gzip_strategies(options) == UINT16_MAX);
+
+	assert(sqsh_compression_options_xz_dictionary_size(options) == UINT32_MAX);
+	assert(sqsh_compression_options_xz_filters(options) == UINT32_MAX);
+
+	assert(sqsh_compression_options_lz4_version(options) == UINT32_MAX);
+	assert(sqsh_compression_options_lz4_flags(options) == UINT32_MAX);
+
+	assert(sqsh_compression_options_zstd_compression_level(options) == 123);
+
+	assert(sqsh_compression_options_lzo_algorithm(options) == UINT32_MAX);
+	assert(sqsh_compression_options_lzo_compression_level(options) ==
+		   UINT32_MAX);
+	sqsh_compression_options_free(options);
+	sqsh__archive_cleanup(&archive);
+}
+
+static void
+load_compression_options_lzo(void) {
+	int rv;
+	struct SqshArchive archive = {0};
+	uint8_t payload[8192] = {
+			SQSH_HEADER,
+			/* inode */
+			METABLOCK_HEADER(0, CHUNK_SIZE(LZO_OPTIONS(0, 0))),
+			LZO_OPTIONS(123, 456)};
+	payload[20] = 3;
+	mk_stub(&archive, payload, sizeof(payload));
+
+	struct SqshCompressionOptions *options =
+			sqsh_compression_options_new(&archive, &rv);
+	assert(rv == 0);
+	assert(options != NULL);
+
+	assert(sqsh_compression_options_size(options) == 8);
+
+	assert(sqsh_compression_options_gzip_compression_level(options) ==
+		   UINT32_MAX);
+	assert(sqsh_compression_options_gzip_compression_level(options) ==
+		   UINT32_MAX);
+	assert(sqsh_compression_options_gzip_window_size(options) == UINT16_MAX);
+	assert(sqsh_compression_options_gzip_strategies(options) == UINT16_MAX);
+
+	assert(sqsh_compression_options_xz_dictionary_size(options) == UINT32_MAX);
+	assert(sqsh_compression_options_xz_filters(options) == UINT32_MAX);
+
+	assert(sqsh_compression_options_lz4_version(options) == UINT32_MAX);
+	assert(sqsh_compression_options_lz4_flags(options) == UINT32_MAX);
+
+	assert(sqsh_compression_options_zstd_compression_level(options) ==
+		   UINT32_MAX);
+
+	assert(sqsh_compression_options_lzo_algorithm(options) == 123);
+	assert(sqsh_compression_options_lzo_compression_level(options) == 456);
 	sqsh_compression_options_free(options);
 	sqsh__archive_cleanup(&archive);
 }
 
 DECLARE_TESTS
-TEST(load_compression_options)
+TEST(load_compression_options_gzip)
+TEST(load_compression_options_xz)
+TEST(load_compression_options_lz4)
+TEST(load_compression_options_zstd)
+TEST(load_compression_options_lzo)
 END_TESTS

--- a/test/common.h
+++ b/test/common.h
@@ -151,9 +151,6 @@
 
 #define CHUNK_SIZE(...) sizeof((uint8_t[]){__VA_ARGS__})
 
-#define GZIP_OPTIONS(level, winsize, strategy) \
-	UINT32_BYTES(level), UINT16_BYTES(winsize), UINT16_BYTES(strategy)
-
 #define DEFAULT_MAPPER sqsh_mapper_impl_static
 /* We're using a ridiculously small block size to
  * test the mappers ability to handle small blocks.

--- a/test/util.c
+++ b/test/util.c
@@ -15,6 +15,8 @@
 const uint8_t *
 mk_stub(struct SqshArchive *sqsh, uint8_t *payload, size_t payload_size) {
 	int rv;
+	const int compression_id =
+			payload[20] ? payload[20] : SQSH_COMPRESSION_GZIP;
 	uint8_t superblock[SQSH_SIZEOF_SUPERBLOCK] = {
 			/* magic */
 			UINT32_BYTES(SQSH_SUPERBLOCK_MAGIC),
@@ -27,7 +29,7 @@ mk_stub(struct SqshArchive *sqsh, uint8_t *payload, size_t payload_size) {
 			/* fragment_entry_count */
 			UINT32_BYTES(0),
 			/* compression_id */
-			UINT16_BYTES(SQSH_COMPRESSION_GZIP),
+			UINT16_BYTES(compression_id),
 			/* block_log */
 			UINT16_BYTES(15),
 			/* flags */


### PR DESCRIPTION
This change adds tests for all compression options to return the correct values. It also tests to get invalid compression options, which should return their UINT*_MAX values.