### PR TITLE
Make sqsh_error_str thread safe, and document that the value may be overwritten

### DIFF
--- a/include/sqsh_error.h
+++ b/include/sqsh_error.h
@@ -107,6 +107,9 @@ void sqsh_perror(int error_code, const char *msg);
 /**
  * @brief Get the error message for the given error code.
  *
+ * This function is thread safe, but the returned string may be overwritten by the next call
+ * to this function on this thread.
+ *
  * @param error_code The error code.
  * @return The error message.
  */


### PR DESCRIPTION
POSIX [does not require](https://pubs.opengroup.org/onlinepubs/9699919799/functions/strerror.html#:~:text=The%20strerror()%20function%20need%20not%20be%20thread%2Dsafe.) `strerror` to be thread safe. Instead, use `strerror_r` to write into our own thread-local buffer.