### PR TITLE
extract: make sure return codes are propagated

### DIFF
--- a/lib/extract/extract_manager.c
+++ b/lib/extract/extract_manager.c
@@ -171,6 +171,10 @@ sqsh__extract_manager_uncompress(
 		}
 
 		rv = sqsh__extractor_finish(&extractor);
+		if (rv < 0) {
+			cx_buffer_cleanup(&buffer);
+			goto out;
+		}
 
 		*target = cx_rc_hash_map_put(&manager->hash_map, address, &buffer);
 	}

--- a/lib/extract/extractor.c
+++ b/lib/extract/extractor.c
@@ -85,7 +85,7 @@ sqsh__extractor_init(
 	}
 
 out:
-	return 0;
+	return rv;
 }
 
 int


### PR DESCRIPTION
This change fixes two bugs where functions mask errors by either returning 0 or not checking the return value of another function.