### PR TITLE
directory_iterator: replace _inode_number with _inode

### DIFF
--- a/include/sqsh_directory.h
+++ b/include/sqsh_directory.h
@@ -106,8 +106,24 @@ sqsh_directory_iterator_name_size(const struct SqshDirectoryIterator *iterator);
  *
  * @return The inode number.
  */
-uint64_t sqsh_directory_iterator_inode_number(
-		const struct SqshDirectoryIterator *iterator);
+uint32_t
+sqsh_directory_iterator_inode(const struct SqshDirectoryIterator *iterator);
+
+/**
+ * @deprecated Since 1.2.0. Use sqsh_directory_iterator_inode() instead.
+ * @memberof SqshDirectoryIterator
+ * @brief Retrieves the inode number of the current entry.
+ *
+ * @param[in] iterator The iterator to use.
+ *
+ * @return The inode number.
+ */
+__attribute__((deprecated("Since 1.2.0. Use sqsh_directory_iterator_inode() "
+						  "instead"))) inline uint64_t
+sqsh_directory_iterator_inode_number(
+		const struct SqshDirectoryIterator *iterator) {
+	return sqsh_directory_iterator_inode(iterator);
+}
 
 /**
  * @memberof SqshDirectoryIterator

--- a/lib/tree/walker.c
+++ b/lib/tree/walker.c
@@ -52,7 +52,7 @@ SQSH_NO_UNUSED int
 update_inode_from_iterator(struct SqshTreeWalker *walker) {
 	// TODO: this should be done from sqsh__file_init.
 	struct SqshDirectoryIterator *iterator = &walker->iterator;
-	uint64_t inode_number = sqsh_directory_iterator_inode_number(iterator);
+	uint32_t inode_number = sqsh_directory_iterator_inode(iterator);
 	uint64_t inode_ref = sqsh_directory_iterator_inode_ref(iterator);
 
 	walker->current_inode_ref = inode_ref;

--- a/tools/fs3.c
+++ b/tools/fs3.c
@@ -271,7 +271,7 @@ fs_readdir(
 	}
 
 	handle->current_stat.st_ino = fs_common_inode_sqsh_to_ino(
-			sqsh_directory_iterator_inode_number(handle->iterator));
+			sqsh_directory_iterator_inode(handle->iterator));
 
 	handle->current_stat.st_mode = fs_common_mode_type(
 			sqsh_directory_iterator_file_type(handle->iterator));


### PR DESCRIPTION
This change deprecates sqsh_directory_iterator_inode_number() with a misleading return type (uint64_t) and replaces it with a new function sqsh_directory_iterator_inode() with a more appropriate return type (uint32_t). inodes in squashfs are by definition 32-bit, so there is no need to return a 64-bit. Also the function name is more consistent with the other functions in libsqsh.