### PR TITLE
directory_iterator: un-inline _inode_number

### DIFF
--- a/include/sqsh_directory.h
+++ b/include/sqsh_directory.h
@@ -119,12 +119,9 @@ sqsh_directory_iterator_inode(const struct SqshDirectoryIterator *iterator);
  * @return The inode number.
  */
 __attribute__((deprecated("Since 1.2.0. Use sqsh_directory_iterator_inode() "
-						  "instead"))) inline uint64_t
+						  "instead"))) uint64_t
 sqsh_directory_iterator_inode_number(
-		const struct SqshDirectoryIterator *iterator) {
-	return sqsh_directory_iterator_inode(iterator);
-}
-
+		const struct SqshDirectoryIterator *iterator);
 /**
  * @memberof SqshDirectoryIterator
  * @brief Retrieves the inode reference of the current entry.

--- a/lib/directory/directory_iterator.c
+++ b/lib/directory/directory_iterator.c
@@ -260,6 +260,12 @@ sqsh_directory_iterator_inode(const struct SqshDirectoryIterator *iterator) {
 	return inode_base + inode_offset;
 }
 
+uint64_t
+sqsh_directory_iterator_inode_number(
+		const struct SqshDirectoryIterator *iterator) {
+	return sqsh_directory_iterator_inode(iterator);
+}
+
 enum SqshFileType
 sqsh_directory_iterator_file_type(
 		const struct SqshDirectoryIterator *iterator) {


### PR DESCRIPTION
This change partially reverts d068ca4 as it breaks the ABI compatibility of the library. It re-introduces sqsh_directory_iterator_inode_number() as a non-inline function.