### PR TITLE
tree_walker: fix _next function.

### DIFF
--- a/lib/tree/walker.c
+++ b/lib/tree/walker.c
@@ -183,8 +183,12 @@ sqsh_tree_walker_next(struct SqshTreeWalker *walker) {
 	if (has_next == false) {
 		return 0;
 	} else {
-		return update_inode_from_iterator(walker);
+		rv = update_inode_from_iterator(walker);
 	}
+	if (rv < 0) {
+		return rv;
+	}
+	return 1;
 }
 
 enum SqshFileType

--- a/test/tree/walker.c
+++ b/test/tree/walker.c
@@ -278,6 +278,54 @@ walker_uninitialized_down(void) {
 	sqsh__archive_cleanup(&archive);
 }
 
+static void
+walker_next(void) {
+	int rv;
+	struct SqshArchive archive = {0};
+	uint8_t payload[] = {
+			/* clang-format off */
+			SQSH_HEADER,
+			/* inode */
+			[INODE_TABLE_OFFSET] = METABLOCK_HEADER(0, 1024),
+			INODE_HEADER(1, 0, 0, 0, 0, 1),
+			INODE_BASIC_DIR(0, 45, 0, 0),
+
+			[DIRECTORY_TABLE_OFFSET] = METABLOCK_HEADER(0, 128),
+			DIRECTORY_HEADER(3, 0, 0),
+			DIRECTORY_ENTRY(128, 2, 1, 2),
+			'e', '1',
+			DIRECTORY_ENTRY(128, 2, 1, 2),
+			'e', '2',
+			DIRECTORY_ENTRY(128, 2, 1, 2),
+			'e', '3',
+			[FRAGMENT_TABLE_OFFSET] = 0,
+			/* clang-format on */
+	};
+	mk_stub(&archive, payload, sizeof(payload));
+
+	struct SqshTreeWalker walker = {0};
+	rv = sqsh__tree_walker_init(&walker, &archive);
+	assert(rv == 0);
+
+	rv = sqsh_tree_walker_to_root(&walker);
+	assert(rv == 0);
+
+	rv = sqsh_tree_walker_next(&walker);
+	assert(rv > 0);
+
+	rv = sqsh_tree_walker_next(&walker);
+	assert(rv > 0);
+
+	rv = sqsh_tree_walker_next(&walker);
+	assert(rv > 0);
+
+	rv = sqsh_tree_walker_next(&walker);
+	assert(rv == 0);
+
+	sqsh__tree_walker_cleanup(&walker);
+	sqsh__archive_cleanup(&archive);
+}
+
 DECLARE_TESTS
 TEST(walker_symlink_open)
 TEST(walker_symlink_recursion)
@@ -285,4 +333,5 @@ TEST(walker_symlink_alternating_recursion)
 TEST(walker_directory_enter)
 TEST(walker_uninitialized_down)
 TEST(walker_uninitialized_up)
+TEST(walker_next)
 END_TESTS


### PR DESCRIPTION
Up to now the return code of the _next function was always 0, even if a next entry was found. The user of the walker had no way to check if the end of the tree was reached. This patch changes the return code to 1 if there is a next entry and 0 if the end of the directory is reached as defined in the documentation. It also adds a test for this case.