### PR TITLE
tree_walker: introduce iterator-like _next2 function

### DIFF
--- a/include/sqsh_tree.h
+++ b/include/sqsh_tree.h
@@ -73,14 +73,35 @@ sqsh_tree_walker_new(struct SqshArchive *archive, int *err);
 SQSH_NO_UNUSED int sqsh_tree_walker_up(struct SqshTreeWalker *walker);
 
 /**
- * @brief Moves the walker to the next entry int the current directory.
+ * @deprecated Since 1.2.0. Use sqsh_tree_walker_next2() instead.
  * @memberof SqshTreeWalker
+ * @brief Moves the walker to the next entry int the current directory.
+ *
+ * This function was deprecated to align the API with other iterator APIs. The
+ * `sqsh_tree_walker_next2()` uses the same signature as the other iterator.
  *
  * @param[in,out]   walker  The walker to use
  *
  * @return 0 on success, less than 0 on error.
  */
-SQSH_NO_UNUSED int sqsh_tree_walker_next(struct SqshTreeWalker *walker);
+__attribute__((deprecated("Since 1.2.0. Use sqsh_directory_walker_next2() "
+						  "instead."))) SQSH_NO_UNUSED int
+sqsh_tree_walker_next(struct SqshTreeWalker *walker);
+
+/**
+ * @deprecated Since 1.2.0. Use sqsh_tree_walker_next2() instead.
+ * @memberof SqshTreeWalker
+ * @brief Moves the walker to the next entry int the current directory.
+ *
+ * @param[in,out]   walker  The walker to use
+ * @param[out]      err     Pointer to an int where the error code will be
+ * stored.
+ *
+ * @retval true if the walker was moved to the next entry.
+ * @retval false if the walker has no more entries to move to or an error
+ */
+SQSH_NO_UNUSED bool
+sqsh_tree_walker_next2(struct SqshTreeWalker *walker, int *err);
 
 /**
  * @brief Returns the inode type of the current entry.

--- a/test/meson.build
+++ b/test/meson.build
@@ -99,7 +99,7 @@ foreach p : sqsh_test
     if sqsh_extra_source.has_key(p)
         sources += sqsh_extra_source[p]
     endif
-    this_c_args = []
+    this_c_args = ['-Wno-deprecated-declarations']
     this_c_args += test_c_args
     this_cpp_args = []
     this_cpp_args += test_cpp_args

--- a/test/tree/walker.c
+++ b/test/tree/walker.c
@@ -326,6 +326,61 @@ walker_next(void) {
 	sqsh__archive_cleanup(&archive);
 }
 
+static void
+walker_next2(void) {
+	int rv;
+	struct SqshArchive archive = {0};
+	uint8_t payload[] = {
+			/* clang-format off */
+			SQSH_HEADER,
+			/* inode */
+			[INODE_TABLE_OFFSET] = METABLOCK_HEADER(0, 1024),
+			INODE_HEADER(1, 0, 0, 0, 0, 1),
+			INODE_BASIC_DIR(0, 45, 0, 0),
+
+			[DIRECTORY_TABLE_OFFSET] = METABLOCK_HEADER(0, 128),
+			DIRECTORY_HEADER(3, 0, 0),
+			DIRECTORY_ENTRY(128, 2, 1, 2),
+			'e', '1',
+			DIRECTORY_ENTRY(128, 2, 1, 2),
+			'e', '2',
+			DIRECTORY_ENTRY(128, 2, 1, 2),
+			'e', '3',
+			[FRAGMENT_TABLE_OFFSET] = 0,
+			/* clang-format on */
+	};
+	mk_stub(&archive, payload, sizeof(payload));
+
+	struct SqshTreeWalker walker = {0};
+	rv = sqsh__tree_walker_init(&walker, &archive);
+	assert(rv == 0);
+
+	rv = sqsh_tree_walker_to_root(&walker);
+	assert(rv == 0);
+
+	bool has_next = sqsh_tree_walker_next2(&walker, &rv);
+	assert(rv == 0);
+	assert(has_next);
+
+	has_next = sqsh_tree_walker_next2(&walker, &rv);
+	assert(rv == 0);
+	assert(has_next);
+
+	has_next = sqsh_tree_walker_next2(&walker, &rv);
+	assert(rv == 0);
+	assert(has_next);
+
+	has_next = sqsh_tree_walker_next2(&walker, &rv);
+	assert(rv == 0);
+	assert(has_next == false);
+
+	rv = sqsh_tree_walker_next2(&walker, &rv);
+	assert(rv == 0);
+
+	sqsh__tree_walker_cleanup(&walker);
+	sqsh__archive_cleanup(&archive);
+}
+
 DECLARE_TESTS
 TEST(walker_symlink_open)
 TEST(walker_symlink_recursion)
@@ -334,4 +389,5 @@ TEST(walker_directory_enter)
 TEST(walker_uninitialized_down)
 TEST(walker_uninitialized_up)
 TEST(walker_next)
+TEST(walker_next2)
 END_TESTS


### PR DESCRIPTION
This change introduces a new function sqsh_tree_walker_next2() which uses the same signature as sqsh_directory_iterator_next(). This harmonizes the API. For the next major release, the old function will be removed and _next2 will be renamed to _next.