### PR TITLE
inode_map: Replace _map_set() with _map_set2()

### DIFF
--- a/include/sqsh_archive.h
+++ b/include/sqsh_archive.h
@@ -102,7 +102,23 @@ sqsh_inode_map_get(const struct SqshInodeMap *map, uint64_t inode_number);
  * @return The inode reference on success, 0 on error.
  */
 SQSH_NO_UNUSED uint64_t sqsh_inode_map_get2(
-		const struct SqshInodeMap *map, uint64_t inode_number, int *err);
+		const struct SqshInodeMap *map, uint32_t inode_number, int *err);
+
+/**
+ * @deprecated Since 1.2.0. Use sqsh_inode_map_set2() instead.
+ * @memberof SqshInodeMap
+ * @brief Sets the inode reference for a given inode number.
+ *
+ * @param[in] map The context to use.
+ * @param[in] inode_number The inode number to set the reference for.
+ * @param[in] inode_ref The inode reference to set.
+ *
+ * @return 0 on success, a negative value on error.
+ */
+__attribute__((deprecated("Since 1.2.0. Use sqsh_inode_map_set2() "
+						  "instead."))) SQSH_NO_UNUSED int
+sqsh_inode_map_set(
+		struct SqshInodeMap *map, uint64_t inode_number, uint64_t inode_ref);
 
 /**
  * @memberof SqshInodeMap
@@ -114,8 +130,8 @@ SQSH_NO_UNUSED uint64_t sqsh_inode_map_get2(
  *
  * @return 0 on success, a negative value on error.
  */
-SQSH_NO_UNUSED int sqsh_inode_map_set(
-		struct SqshInodeMap *map, uint64_t inode_number, uint64_t inode_ref);
+SQSH_NO_UNUSED int sqsh_inode_map_set2(
+		struct SqshInodeMap *map, uint32_t inode_number, uint64_t inode_ref);
 
 /***************************************
  * archive/superblock_context.c

--- a/include/sqsh_archive_private.h
+++ b/include/sqsh_archive_private.h
@@ -112,7 +112,7 @@ struct SqshInodeMap {
  * @return 0 on success, a negative value on error.
  */
 SQSH_NO_UNUSED SQSH_NO_EXPORT int
-sqsh_inode_map_init(struct SqshInodeMap *map, struct SqshArchive *archive);
+sqsh__inode_map_init(struct SqshInodeMap *map, struct SqshArchive *archive);
 
 /**
  * @internal
@@ -123,7 +123,7 @@ sqsh_inode_map_init(struct SqshInodeMap *map, struct SqshArchive *archive);
  *
  * @return 0 on success, a negative value on error.
  */
-SQSH_NO_EXPORT int sqsh_inode_map_cleanup(struct SqshInodeMap *map);
+SQSH_NO_EXPORT int sqsh__inode_map_cleanup(struct SqshInodeMap *map);
 
 /***************************************
  * archive/superblock.c

--- a/lib/archive/archive.c
+++ b/lib/archive/archive.c
@@ -300,7 +300,7 @@ sqsh_archive_inode_map(
 		goto out;
 	}
 	if (!(archive->initialized & INITIALIZED_INODE_MAP)) {
-		rv = sqsh_inode_map_init(&archive->inode_map, archive);
+		rv = sqsh__inode_map_init(&archive->inode_map, archive);
 		if (rv < 0) {
 			goto out;
 		}
@@ -364,7 +364,7 @@ sqsh__archive_cleanup(struct SqshArchive *archive) {
 		sqsh__extract_manager_cleanup(&archive->data_extract_manager);
 	}
 	if (is_initialized(archive, INITIALIZED_INODE_MAP)) {
-		sqsh_inode_map_cleanup(&archive->inode_map);
+		sqsh__inode_map_cleanup(&archive->inode_map);
 	}
 	sqsh__extract_manager_cleanup(&archive->metablock_extract_manager);
 	sqsh__superblock_cleanup(&archive->superblock);

--- a/lib/archive/inode_map.c
+++ b/lib/archive/inode_map.c
@@ -79,7 +79,7 @@ out:
 
 uint64_t
 sqsh_inode_map_get2(
-		const struct SqshInodeMap *map, uint64_t inode_number, int *err) {
+		const struct SqshInodeMap *map, uint32_t inode_number, int *err) {
 	int rv = 0;
 	uint64_t inode_ref = 0;
 	atomic_uint_fast64_t *inode_refs = map->inode_refs;
@@ -109,14 +109,9 @@ out:
 	return inode_ref;
 }
 
-uint64_t
-sqsh_inode_map_get(const struct SqshInodeMap *map, uint64_t inode_number) {
-	return sqsh_inode_map_get2(map, inode_number, NULL);
-}
-
 int
-sqsh_inode_map_set(
-		struct SqshInodeMap *map, uint64_t inode_number, uint64_t inode_ref) {
+sqsh_inode_map_set2(
+		struct SqshInodeMap *map, uint32_t inode_number, uint64_t inode_ref) {
 	uint64_t old_value;
 	atomic_uint_fast64_t *inode_refs = map->inode_refs;
 
@@ -131,6 +126,17 @@ sqsh_inode_map_set(
 		}
 	}
 	return 0;
+}
+
+uint64_t
+sqsh_inode_map_get(const struct SqshInodeMap *map, uint64_t inode_number) {
+	return sqsh_inode_map_get2(map, inode_number, NULL);
+}
+
+int
+sqsh_inode_map_set(
+		struct SqshInodeMap *map, uint64_t inode_number, uint64_t inode_ref) {
+	return sqsh_inode_map_set2(map, inode_number, inode_ref);
 }
 
 int

--- a/lib/archive/inode_map.c
+++ b/lib/archive/inode_map.c
@@ -52,7 +52,7 @@
 // empty inodes without memset()ing the inode map to all `UINT64_MAX`s.
 
 int
-sqsh_inode_map_init(struct SqshInodeMap *map, struct SqshArchive *archive) {
+sqsh__inode_map_init(struct SqshInodeMap *map, struct SqshArchive *archive) {
 	int rv = 0;
 	const struct SqshSuperblock *superblock = sqsh_archive_superblock(archive);
 	const uint32_t inode_count = sqsh_superblock_inode_count(superblock);
@@ -140,7 +140,7 @@ sqsh_inode_map_set(
 }
 
 int
-sqsh_inode_map_cleanup(struct SqshInodeMap *map) {
+sqsh__inode_map_cleanup(struct SqshInodeMap *map) {
 	free(map->inode_refs);
 	return 0;
 }

--- a/lib/file/file.c
+++ b/lib/file/file.c
@@ -188,7 +188,7 @@ sqsh__file_init(
 	if (rv < 0) {
 		goto out;
 	}
-	rv = sqsh_inode_map_set(inode_map, sqsh_file_inode(inode), inode_ref);
+	rv = sqsh_inode_map_set2(inode_map, sqsh_file_inode(inode), inode_ref);
 
 out:
 	if (rv < 0) {

--- a/lib/tree/walker.c
+++ b/lib/tree/walker.c
@@ -56,7 +56,7 @@ update_inode_from_iterator(struct SqshTreeWalker *walker) {
 	uint64_t inode_ref = sqsh_directory_iterator_inode_ref(iterator);
 
 	walker->current_inode_ref = inode_ref;
-	return sqsh_inode_map_set(walker->inode_map, inode_number, inode_ref);
+	return sqsh_inode_map_set2(walker->inode_map, inode_number, inode_ref);
 }
 
 static int
@@ -93,7 +93,7 @@ enter_directory(struct SqshTreeWalker *walker, uint64_t inode_ref) {
 
 	const uint64_t inode_number = sqsh_file_inode(cwd);
 	walker->current_inode_ref = inode_ref;
-	rv = sqsh_inode_map_set(walker->inode_map, inode_number, inode_ref);
+	rv = sqsh_inode_map_set2(walker->inode_map, inode_number, inode_ref);
 
 out:
 	return rv;

--- a/test/archive/inode_map.c
+++ b/test/archive/inode_map.c
@@ -50,7 +50,7 @@ insert_inode_ref(void) {
 
 	struct SqshInodeMap map = {0};
 
-	rv = sqsh_inode_map_init(&map, &archive);
+	rv = sqsh__inode_map_init(&map, &archive);
 	assert(rv == 0);
 
 	rv = sqsh_inode_map_set(&map, 1, 4242);
@@ -60,7 +60,7 @@ insert_inode_ref(void) {
 	assert(rv == 0);
 	assert(inode_ref == 4242);
 
-	sqsh_inode_map_cleanup(&map);
+	sqsh__inode_map_cleanup(&map);
 	sqsh__archive_cleanup(&archive);
 }
 
@@ -75,7 +75,7 @@ insert_invalid_inode(void) {
 
 	struct SqshInodeMap map = {0};
 
-	rv = sqsh_inode_map_init(&map, &archive);
+	rv = sqsh__inode_map_init(&map, &archive);
 	assert(rv == 0);
 
 	rv = sqsh_inode_map_set(&map, 0, 4242);
@@ -84,7 +84,7 @@ insert_invalid_inode(void) {
 	rv = sqsh_inode_map_set(&map, 1000, 4242);
 	assert(rv == -SQSH_ERROR_OUT_OF_BOUNDS);
 
-	sqsh_inode_map_cleanup(&map);
+	sqsh__inode_map_cleanup(&map);
 	sqsh__archive_cleanup(&archive);
 }
 
@@ -99,13 +99,13 @@ insert_invalid_inode_ref(void) {
 
 	struct SqshInodeMap map = {0};
 
-	rv = sqsh_inode_map_init(&map, &archive);
+	rv = sqsh__inode_map_init(&map, &archive);
 	assert(rv == 0);
 
 	rv = sqsh_inode_map_set(&map, 1, UINT64_MAX);
 	assert(rv == -SQSH_ERROR_INVALID_ARGUMENT);
 
-	sqsh_inode_map_cleanup(&map);
+	sqsh__inode_map_cleanup(&map);
 	sqsh__archive_cleanup(&archive);
 }
 
@@ -121,7 +121,7 @@ get_invalid_inode(void) {
 
 	struct SqshInodeMap map = {0};
 
-	rv = sqsh_inode_map_init(&map, &archive);
+	rv = sqsh__inode_map_init(&map, &archive);
 	assert(rv == 0);
 
 	inode_ref = sqsh_inode_map_get2(&map, 424242, &rv);
@@ -132,7 +132,7 @@ get_invalid_inode(void) {
 	assert(rv == -SQSH_ERROR_OUT_OF_BOUNDS);
 	assert(inode_ref == 0);
 
-	sqsh_inode_map_cleanup(&map);
+	sqsh__inode_map_cleanup(&map);
 	sqsh__archive_cleanup(&archive);
 }
 
@@ -148,14 +148,14 @@ get_unknown_inode_ref(void) {
 
 	struct SqshInodeMap map = {0};
 
-	rv = sqsh_inode_map_init(&map, &archive);
+	rv = sqsh__inode_map_init(&map, &archive);
 	assert(rv == 0);
 
 	inode_ref = sqsh_inode_map_get2(&map, 1, &rv);
 	assert(rv == -SQSH_ERROR_NO_SUCH_ELEMENT);
 	assert(inode_ref == 0);
 
-	sqsh_inode_map_cleanup(&map);
+	sqsh__inode_map_cleanup(&map);
 	sqsh__archive_cleanup(&archive);
 }
 
@@ -170,7 +170,7 @@ insert_inconsistent_mapping(void) {
 
 	struct SqshInodeMap map = {0};
 
-	rv = sqsh_inode_map_init(&map, &archive);
+	rv = sqsh__inode_map_init(&map, &archive);
 	assert(rv == 0);
 
 	rv = sqsh_inode_map_set(&map, 1, 4242);
@@ -182,7 +182,7 @@ insert_inconsistent_mapping(void) {
 	rv = sqsh_inode_map_set(&map, 1, 2424);
 	assert(rv == -SQSH_ERROR_INODE_MAP_IS_INCONSISTENT);
 
-	sqsh_inode_map_cleanup(&map);
+	sqsh__inode_map_cleanup(&map);
 	sqsh__archive_cleanup(&archive);
 }
 

--- a/tools/fs3.c
+++ b/tools/fs3.c
@@ -153,7 +153,7 @@ fs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name) {
 		goto out;
 	}
 
-	rv = sqsh_inode_map_set(context.inode_map, inode_number, inode_ref);
+	rv = sqsh_inode_map_set2(context.inode_map, inode_number, inode_ref);
 	if (rv < 0) {
 		fuse_reply_err(req, -fs_common_map_err(rv));
 		goto out;


### PR DESCRIPTION
This changes the signature of _map_set() to take a uint32_t instead of an uint64_t. This harmonizes the inode type used in libsqsh to be uint32_t everywhere. For backwards compatibility, _map_set() is kept as a deprecated wrapper around _map_set2().