### PR TITLE
directory_iterator: fix potential over-/underflow

### DIFF
--- a/include/sqsh_directory_private.h
+++ b/include/sqsh_directory_private.h
@@ -60,6 +60,7 @@ struct SqshDirectoryIterator {
 	struct SqshMetablockReader metablock;
 	size_t remaining_entries;
 	sqsh_index_t next_offset;
+	uint32_t current_inode;
 
 	uint32_t start_base;
 	uint32_t inode_base;

--- a/test/directory/directory_iterator.c
+++ b/test/directory/directory_iterator.c
@@ -33,6 +33,7 @@
  */
 
 #include "../common.h"
+#include <stdint.h>
 #include <testlib.h>
 
 #include "../../include/sqsh_archive_private.h"
@@ -295,6 +296,117 @@ iter_over_corrupt_header_too_small(void) {
 	sqsh__archive_cleanup(&archive);
 }
 
+static void
+iter_inode_overflow(void) {
+	int rv;
+	struct SqshArchive archive = {0};
+	uint8_t payload[] = {
+			/* clang-format off */
+			SQSH_HEADER,
+			/* inode */
+			[INODE_TABLE_OFFSET] = METABLOCK_HEADER(0, 1024),
+			INODE_HEADER(1, 0, 0, 0, 0, 1),
+			INODE_BASIC_DIR(0, 1024, 0, 0),
+			[DIRECTORY_TABLE_OFFSET] = METABLOCK_HEADER(0, 128),
+			DIRECTORY_HEADER(1, 0, UINT32_MAX),
+			DIRECTORY_ENTRY(128, 3, 3, 1),
+			'd',
+			[FRAGMENT_TABLE_OFFSET] = 0,
+			/* clang-format on */
+	};
+	mk_stub(&archive, payload, sizeof(payload));
+
+	struct SqshFile file = {0};
+	rv = sqsh__file_init(&file, &archive, 0);
+	assert(rv == 0);
+
+	struct SqshDirectoryIterator iter = {0};
+	rv = sqsh__directory_iterator_init(&iter, &file);
+	assert(rv == 0);
+
+	bool has_next = sqsh_directory_iterator_next(&iter, &rv);
+	assert(rv == -SQSH_ERROR_CORRUPTED_DIRECTORY_ENTRY);
+	assert(has_next == false);
+
+	sqsh__directory_iterator_cleanup(&iter);
+	sqsh__file_cleanup(&file);
+	sqsh__archive_cleanup(&archive);
+}
+
+static void
+iter_inode_underflow(void) {
+	int rv;
+	struct SqshArchive archive = {0};
+	uint8_t payload[] = {
+			/* clang-format off */
+			SQSH_HEADER,
+			/* inode */
+			[INODE_TABLE_OFFSET] = METABLOCK_HEADER(0, 1024),
+			INODE_HEADER(1, 0, 0, 0, 0, 1),
+			INODE_BASIC_DIR(0, 1024, 0, 0),
+			[DIRECTORY_TABLE_OFFSET] = METABLOCK_HEADER(0, 128),
+			DIRECTORY_HEADER(1, 0, 12),
+			DIRECTORY_ENTRY(128, -13, 3, 1),
+			'd',
+			[FRAGMENT_TABLE_OFFSET] = 0,
+			/* clang-format on */
+	};
+	mk_stub(&archive, payload, sizeof(payload));
+
+	struct SqshFile file = {0};
+	rv = sqsh__file_init(&file, &archive, 0);
+	assert(rv == 0);
+
+	struct SqshDirectoryIterator iter = {0};
+	rv = sqsh__directory_iterator_init(&iter, &file);
+	assert(rv == 0);
+
+	bool has_next = sqsh_directory_iterator_next(&iter, &rv);
+	assert(rv == -SQSH_ERROR_CORRUPTED_DIRECTORY_ENTRY);
+	assert(has_next == false);
+
+	sqsh__directory_iterator_cleanup(&iter);
+	sqsh__file_cleanup(&file);
+	sqsh__archive_cleanup(&archive);
+}
+
+static void
+iter_inode_to_zero(void) {
+	int rv;
+	struct SqshArchive archive = {0};
+	uint8_t payload[] = {
+			/* clang-format off */
+			SQSH_HEADER,
+			/* inode */
+			[INODE_TABLE_OFFSET] = METABLOCK_HEADER(0, 1024),
+			INODE_HEADER(1, 0, 0, 0, 0, 1),
+			INODE_BASIC_DIR(0, 1024, 0, 0),
+			[DIRECTORY_TABLE_OFFSET] = METABLOCK_HEADER(0, 128),
+			DIRECTORY_HEADER(1, 0, 12),
+			DIRECTORY_ENTRY(128, -12, 3, 1),
+			'd',
+			[FRAGMENT_TABLE_OFFSET] = 0,
+			/* clang-format on */
+	};
+	mk_stub(&archive, payload, sizeof(payload));
+
+	struct SqshFile file = {0};
+	rv = sqsh__file_init(&file, &archive, 0);
+	assert(rv == 0);
+
+	struct SqshDirectoryIterator iter = {0};
+	rv = sqsh__directory_iterator_init(&iter, &file);
+	assert(rv == 0);
+
+	bool has_next = sqsh_directory_iterator_next(&iter, &rv);
+	assert(rv == -SQSH_ERROR_CORRUPTED_DIRECTORY_ENTRY);
+	assert(has_next == false);
+
+	sqsh__directory_iterator_cleanup(&iter);
+	sqsh__file_cleanup(&file);
+	sqsh__archive_cleanup(&archive);
+}
+
 DECLARE_TESTS
 TEST(iter_two_files)
 TEST(iter_invalid_file_name_with_slash)
@@ -302,4 +414,7 @@ TEST(iter_invalid_file_name_with_0)
 TEST(iter_invalid_file_type)
 TEST(iter_inconsistent_file_type)
 TEST(iter_over_corrupt_header_too_small)
+TEST(iter_inode_overflow)
+TEST(iter_inode_underflow)
+TEST(iter_inode_to_zero)
 END_TESTS


### PR DESCRIPTION
This change improves the inode calculation in the directory iterators. Before this change the inode was checked in check_inode_consistency() and then calculated naively in directory_iterator_inode(). After this change the inode is precalculated, checked more intensively and cached in update_inode(). director_iterator_inode() is a simple getter for the cached value.

This change also includes test cases for the directory iterator that check the new behavior.