### PR TITLE
tree: rename walker to path resolver.

### DIFF
--- a/include/sqsh_tree.h
+++ b/include/sqsh_tree.h
@@ -45,51 +45,35 @@ extern "C" {
 struct SqshArchive;
 
 /***************************************
- * tree/walker.c
+ * tree/path_resolver.c
  */
 
-struct SqshTreeWalker;
+struct SqshPathResolver;
 
 /**
- * @brief Creates a new SqshTreeWalker object at the root inode.
- * @memberof SqshTreeWalker
+ * @brief Creates a new SqshPathResolver object at the root inode.
+ * @memberof SqshPathResolver
  *
  * @param[in]   archive  The archive to use
  * @param[out]  err      Pointer to an int where the error code will be stored.
  *
  * @return a new file reader.
  */
-struct SqshTreeWalker *
-sqsh_tree_walker_new(struct SqshArchive *archive, int *err);
+struct SqshPathResolver *
+sqsh_path_resolver_new(struct SqshArchive *archive, int *err);
 
 /**
  * @brief Moves the walker one level up
- * @memberof SqshTreeWalker
+ * @memberof SqshPathResolver
  *
  * @param[in,out]   walker  The walker to use
  *
  * @return 0 on success, less than 0 on error.
  */
-SQSH_NO_UNUSED int sqsh_tree_walker_up(struct SqshTreeWalker *walker);
+SQSH_NO_UNUSED int sqsh_path_resolver_up(struct SqshPathResolver *walker);
 
 /**
- * @deprecated Since 1.2.0. Use sqsh_tree_walker_next2() instead.
- * @memberof SqshTreeWalker
- * @brief Moves the walker to the next entry int the current directory.
- *
- * This function was deprecated to align the API with other iterator APIs. The
- * `sqsh_tree_walker_next2()` uses the same signature as the other iterator.
- *
- * @param[in,out]   walker  The walker to use
- *
- * @return 0 on success, less than 0 on error.
- */
-__attribute__((deprecated("Since 1.2.0. Use sqsh_directory_walker_next2() "
-						  "instead."))) SQSH_NO_UNUSED int
-sqsh_tree_walker_next(struct SqshTreeWalker *walker);
-
-/**
- * @memberof SqshTreeWalker
+ * @memberof SqshPathResolver
  * @brief Moves the walker to the next entry int the current directory.
  *
  * @param[in,out]   walker  The walker to use
@@ -101,41 +85,42 @@ sqsh_tree_walker_next(struct SqshTreeWalker *walker);
  * occured.
  */
 SQSH_NO_UNUSED bool
-sqsh_tree_walker_next2(struct SqshTreeWalker *walker, int *err);
+sqsh_path_resolver_next(struct SqshPathResolver *walker, int *err);
 
 /**
  * @brief Returns the inode type of the current entry.
- * @memberof SqshTreeWalker
+ * @memberof SqshPathResolver
  *
  * @param[in]   walker  The walker to use
  *
  * @return the inode type of the current entry.
  */
-enum SqshFileType sqsh_tree_walker_type(const struct SqshTreeWalker *walker);
+enum SqshFileType
+sqsh_path_resolver_type(const struct SqshPathResolver *walker);
 
 /**
  * @brief Returns the name of the current entry. This entry is not zero
  * terminated.
- * @memberof SqshTreeWalker
+ * @memberof SqshPathResolver
  *
  * @param[in]   walker  The walker to use
  *
  * @return the name of the current entry.
  */
-const char *sqsh_tree_walker_name(const struct SqshTreeWalker *walker);
+const char *sqsh_path_resolver_name(const struct SqshPathResolver *walker);
 
 /**
- * @memberof SqshTreeWalker
+ * @memberof SqshPathResolver
  * @brief Returns the size of the name of the current entry.
  *
  * @param[in]   walker  The walker to use
  *
  * @return the size of the name of the current entry.
  */
-uint16_t sqsh_tree_walker_name_size(const struct SqshTreeWalker *walker);
+uint16_t sqsh_path_resolver_name_size(const struct SqshPathResolver *walker);
 
 /**
- * @memberof SqshTreeWalker
+ * @memberof SqshPathResolver
  * @brief creates a heap allocated copy of the name of the current entry.
  *
  * The caller is responsible for calling free() on the returned pointer.
@@ -147,9 +132,199 @@ uint16_t sqsh_tree_walker_name_size(const struct SqshTreeWalker *walker);
  * @return the name of the current entry.
  */
 SQSH_NO_UNUSED char *
+sqsh_path_resolver_name_dup(const struct SqshPathResolver *walker);
+
+/**
+ * @brief reverts the walker to the begining of the current directory.
+ * @memberof SqshPathResolver
+ *
+ * @param[in,out]   walker  The walker to use
+ *
+ * @return 0 on success, less than 0 on error.
+ */
+SQSH_NO_UNUSED int sqsh_path_resolver_revert(struct SqshPathResolver *walker);
+
+/**
+ * @brief Looks up an entry in the current directory.
+ * @memberof SqshPathResolver
+ *
+ * @param[in,out]   walker  The walker to use
+ * @param[in]       name    The name of the entry to look up.
+ * @param[in]       name_size The size of the name.
+ *
+ * @return 0 on success, less than 0 on error.
+ */
+SQSH_NO_UNUSED int sqsh_path_resolver_lookup(
+		struct SqshPathResolver *walker, const char *name,
+		const size_t name_size);
+
+/**
+ * @brief Lets the walker enter the current entry.
+ * @memberof SqshPathResolver
+ *
+ * @param[in,out]   walker  The walker to use
+ *
+ * @return 0 on success, less than 0 on error.
+ */
+SQSH_NO_UNUSED int sqsh_path_resolver_down(struct SqshPathResolver *walker);
+
+/**
+ * @brief Moves the walker to the root directory.
+ * @memberof SqshPathResolver
+ *
+ * @param[in,out]   walker  The walker to use
+ *
+ * @return 0 on success, less than 0 on error.
+ */
+SQSH_NO_UNUSED int sqsh_path_resolver_to_root(struct SqshPathResolver *walker);
+
+/**
+ * @brief Returns the inode of the current entry.
+ * @memberof SqshPathResolver
+ *
+ * @param[in,out]   walker  The walker to use
+ * @param[out]      err     Pointer to an int where the error code will be
+ *
+ * @return the inode of the current entry.
+ */
+SQSH_NO_UNUSED struct SqshFile *
+sqsh_path_resolver_open_file(const struct SqshPathResolver *walker, int *err);
+
+/**
+ * @memberof SqshPathResolver
+ * @brief Resolve a path with the tree walker.
+ *
+ * This function will resolve the given path with the tree walker. The base is
+ * the current directory.
+ *
+ * @param[in,out]   walker           The walker to use
+ * @param[in]       path             The path to resolve.
+ * @param[in]       follow_symlinks  Whether to follow symlinks.
+ *
+ * @return the inode of the current entry.
+ */
+SQSH_NO_UNUSED int sqsh_path_resolver_resolve(
+		struct SqshPathResolver *walker, const char *path,
+		bool follow_symlinks);
+
+/**
+ * @brief Cleans up resources used by a SqshPathResolver struct.
+ * @memberof SqshPathResolver
+ *
+ * @param[in,out] reader The file reader struct to clean up.
+ *
+ * @return 0 on success, less than 0 on error.
+ */
+int sqsh_path_resolver_free(struct SqshPathResolver *reader);
+
+/***************************************
+ * tree/walker.c
+ */
+
+struct SqshTreeWalker;
+
+/**
+ * @deprecated Since 1.2.0. Use sqsh_path_resolver_new() instead.
+ * @brief Creates a new SqshTreeWalker object at the root inode.
+ * @memberof SqshTreeWalker
+ *
+ * @param[in]   archive  The archive to use
+ * @param[out]  err      Pointer to an int where the error code will be stored.
+ *
+ * @return a new file reader.
+ */
+__attribute__((deprecated("Since 1.2.0. Use sqsh_path_resolver_new() "
+						  "instead."))) struct SqshTreeWalker *
+sqsh_tree_walker_new(struct SqshArchive *archive, int *err);
+
+/**
+ * @deprecated Since 1.2.0. Use sqsh_path_resolver_up() instead.
+ * @brief Moves the walker one level up
+ * @memberof SqshTreeWalker
+ *
+ * @param[in,out]   walker  The walker to use
+ *
+ * @return 0 on success, less than 0 on error.
+ */
+__attribute__((deprecated("Since 1.2.0. Use sqsh_path_resolver_up() "
+						  "instead."))) SQSH_NO_UNUSED int
+sqsh_tree_walker_up(struct SqshTreeWalker *walker);
+
+/**
+ * @deprecated Since 1.2.0. Use sqsh_path_resolver_next() instead.
+ * @memberof SqshTreeWalker
+ * @brief Moves the walker to the next entry int the current directory.
+ *
+ * This function was deprecated to align the API with other iterator APIs. The
+ * `sqsh_tree_walker_next2()` uses the same signature as the other iterator.
+ *
+ * @param[in,out]   walker  The walker to use
+ *
+ * @return 0 on success, less than 0 on error.
+ */
+__attribute__((deprecated("Since 1.2.0. Use sqsh_path_resolver_next() "
+						  "instead."))) SQSH_NO_UNUSED int
+sqsh_tree_walker_next(struct SqshTreeWalker *walker);
+
+/**
+ * @deprecated Since 1.2.0. Use sqsh_tree_walker_type() instead.
+ * @brief Returns the inode type of the current entry.
+ * @memberof SqshTreeWalker
+ *
+ * @param[in]   walker  The walker to use
+ *
+ * @return the inode type of the current entry.
+ */
+__attribute__((deprecated("Since 1.2.0. Use sqsh_tree_walker_type() "
+						  "instead."))) enum SqshFileType
+sqsh_tree_walker_type(const struct SqshTreeWalker *walker);
+
+/**
+ * @deprecated Since 1.2.0. Use sqsh_tree_walker_name() instead.
+ * @brief Returns the name of the current entry. This entry is not zero
+ * terminated.
+ * @memberof SqshTreeWalker
+ *
+ * @param[in]   walker  The walker to use
+ *
+ * @return the name of the current entry.
+ */
+__attribute__((deprecated("Since 1.2.0. Use sqsh_tree_walker_name() "
+						  "instead."))) const char *
+sqsh_tree_walker_name(const struct SqshTreeWalker *walker);
+
+/**
+ * @deprecated Since 1.2.0. Use sqsh_tree_walker_name_size() instead.
+ * @memberof SqshTreeWalker
+ * @brief Returns the size of the name of the current entry.
+ *
+ * @param[in]   walker  The walker to use
+ *
+ * @return the size of the name of the current entry.
+ */
+__attribute__((deprecated("Since 1.2.0. Use sqsh_tree_walker_name_size() "
+						  "instead."))) uint16_t
+sqsh_tree_walker_name_size(const struct SqshTreeWalker *walker);
+
+/**
+ * @deprecated Since 1.2.0. Use sqsh_tree_walker_name_dup() instead.
+ * @memberof SqshTreeWalker
+ * @brief creates a heap allocated copy of the name of the current entry.
+ *
+ * The caller is responsible for calling free() on the returned pointer.
+ *
+ * The returned string is 0 terminated.
+ *
+ * @param[in]   walker  The walker to use
+ *
+ * @return the name of the current entry.
+ */
+__attribute__((deprecated("Since 1.2.0. Use sqsh_tree_walker_name_dup() "
+						  "instead."))) SQSH_NO_UNUSED char *
 sqsh_tree_walker_name_dup(const struct SqshTreeWalker *walker);
 
 /**
+ * @deprecated Since 1.2.0. Use sqsh_path_resolver_revert() instead.
  * @brief reverts the walker to the begining of the current directory.
  * @memberof SqshTreeWalker
  *
@@ -157,9 +332,12 @@ sqsh_tree_walker_name_dup(const struct SqshTreeWalker *walker);
  *
  * @return 0 on success, less than 0 on error.
  */
-SQSH_NO_UNUSED int sqsh_tree_walker_revert(struct SqshTreeWalker *walker);
+__attribute__((deprecated("Since 1.2.0. Use sqsh_path_resolver_revert() "
+						  "instead."))) SQSH_NO_UNUSED int
+sqsh_tree_walker_revert(struct SqshTreeWalker *walker);
 
 /**
+ * @deprecated Since 1.2.0. Use sqsh_path_resolver_lookup() instead.
  * @brief Looks up an entry in the current directory.
  * @memberof SqshTreeWalker
  *
@@ -169,11 +347,14 @@ SQSH_NO_UNUSED int sqsh_tree_walker_revert(struct SqshTreeWalker *walker);
  *
  * @return 0 on success, less than 0 on error.
  */
-SQSH_NO_UNUSED int sqsh_tree_walker_lookup(
+__attribute__((deprecated("Since 1.2.0. Use sqsh_path_resolver_lookup() "
+						  "instead."))) SQSH_NO_UNUSED int
+sqsh_tree_walker_lookup(
 		struct SqshTreeWalker *walker, const char *name,
 		const size_t name_size);
 
 /**
+ * @deprecated Since 1.2.0. Use sqsh_path_resolver_down() instead.
  * @brief Lets the walker enter the current entry.
  * @memberof SqshTreeWalker
  *
@@ -181,9 +362,12 @@ SQSH_NO_UNUSED int sqsh_tree_walker_lookup(
  *
  * @return 0 on success, less than 0 on error.
  */
-SQSH_NO_UNUSED int sqsh_tree_walker_down(struct SqshTreeWalker *walker);
+__attribute__((deprecated("Since 1.2.0. Use sqsh_path_resolver_down() "
+						  "instead."))) SQSH_NO_UNUSED int
+sqsh_tree_walker_down(struct SqshTreeWalker *walker);
 
 /**
+ * @deprecated Since 1.2.0. Use sqsh_path_resolver_to_root() instead.
  * @brief Moves the walker to the root directory.
  * @memberof SqshTreeWalker
  *
@@ -191,9 +375,12 @@ SQSH_NO_UNUSED int sqsh_tree_walker_down(struct SqshTreeWalker *walker);
  *
  * @return 0 on success, less than 0 on error.
  */
-SQSH_NO_UNUSED int sqsh_tree_walker_to_root(struct SqshTreeWalker *walker);
+__attribute__((deprecated("Since 1.2.0. Use sqsh_path_resolver_to_root() "
+						  "instead."))) SQSH_NO_UNUSED int
+sqsh_tree_walker_to_root(struct SqshTreeWalker *walker);
 
 /**
+ * @deprecated Since 1.2.0. Use sqsh_path_resolver_open_file() instead.
  * @brief Returns the inode of the current entry.
  * @memberof SqshTreeWalker
  *
@@ -202,10 +389,12 @@ SQSH_NO_UNUSED int sqsh_tree_walker_to_root(struct SqshTreeWalker *walker);
  *
  * @return the inode of the current entry.
  */
-SQSH_NO_UNUSED struct SqshFile *
+__attribute__((deprecated("Since 1.2.0. Use sqsh_path_resolver_open_file() "
+						  "instead."))) SQSH_NO_UNUSED struct SqshFile *
 sqsh_tree_walker_open_file(const struct SqshTreeWalker *walker, int *err);
 
 /**
+ * @deprecated Since 1.2.0. Use sqsh_path_resolver_open_file() instead.
  * @memberof SqshTreeWalker
  * @brief Resolve a path with the tree walker.
  *
@@ -218,10 +407,13 @@ sqsh_tree_walker_open_file(const struct SqshTreeWalker *walker, int *err);
  *
  * @return the inode of the current entry.
  */
-SQSH_NO_UNUSED int sqsh_tree_walker_resolve(
+__attribute__((deprecated("Since 1.2.0. Use sqsh_path_resolver_resolve() "
+						  "instead."))) SQSH_NO_UNUSED int
+sqsh_tree_walker_resolve(
 		struct SqshTreeWalker *walker, const char *path, bool follow_symlinks);
 
 /**
+ * @deprecated Since 1.2.0. Use sqsh_path_resolver_free() instead.
  * @brief Cleans up resources used by a SqshTreeWalker struct.
  * @memberof SqshTreeWalker
  *
@@ -229,7 +421,9 @@ SQSH_NO_UNUSED int sqsh_tree_walker_resolve(
  *
  * @return 0 on success, less than 0 on error.
  */
-int sqsh_tree_walker_free(struct SqshTreeWalker *reader);
+__attribute__((deprecated("Since 1.2.0. Use sqsh_path_resolver_free() "
+						  "instead."))) int
+sqsh_tree_walker_free(struct SqshTreeWalker *reader);
 
 #ifdef __cplusplus
 }

--- a/include/sqsh_tree_private.h
+++ b/include/sqsh_tree_private.h
@@ -45,13 +45,13 @@ extern "C" {
 struct SqshArchive;
 
 /***************************************
- * tree/walker.c
+ * tree/path_resolver.c
  */
 
 /**
  * @brief A walker over the contents of a file.
  */
-struct SqshTreeWalker {
+struct SqshPathResolver {
 	/**
 	 * @privatesection
 	 */
@@ -67,27 +67,41 @@ struct SqshTreeWalker {
 
 /**
  * @internal
- * @memberof SqshTreeWalker
- * @brief Initializes a SqshTreeWalker struct.
+ * @memberof SqshPathResolver
+ * @brief Initializes a SqshPathResolver struct.
  *
  * @param[out] walker   The file walker to initialize.
  * @param[in]  archive  The archive to use
  *
  * @return 0 on success, less than 0 on error.
  */
-SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__tree_walker_init(
-		struct SqshTreeWalker *walker, struct SqshArchive *archive);
+SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__path_resolver_init(
+		struct SqshPathResolver *walker, struct SqshArchive *archive);
 
 /**
  * @internal
- * @memberof SqshTreeWalker
+ * @memberof SqshPathResolver
  * @brief Frees the resources used by the file walker.
  *
  * @param walker The file walker to clean up.
  *
  * @return 0 on success, less than 0 on error.
  */
-SQSH_NO_EXPORT int sqsh__tree_walker_cleanup(struct SqshTreeWalker *walker);
+SQSH_NO_EXPORT int sqsh__path_resolver_cleanup(struct SqshPathResolver *walker);
+/***************************************
+ * tree/walker.c
+ */
+
+/**
+ * @brief A walker over the contents of a file.
+ * @deprecated Since 1.2.0. Use struct SqshPathResolver instead.
+ */
+struct SqshTreeWalker {
+	/**
+	 * @privatesection
+	 */
+	struct SqshPathResolver inner;
+} __attribute__((deprecated("Since 1.2.0. Use SqshPathResolver instead.")));
 
 #ifdef __cplusplus
 }

--- a/lib/read/easy/file.c
+++ b/lib/read/easy/file.c
@@ -48,14 +48,14 @@
 bool
 sqsh_easy_file_exists(struct SqshArchive *archive, const char *path, int *err) {
 	int rv = 0;
-	struct SqshTreeWalker walker = {0};
+	struct SqshPathResolver resolver = {0};
 	bool exists = false;
 
-	rv = sqsh__tree_walker_init(&walker, archive);
+	rv = sqsh__path_resolver_init(&resolver, archive);
 	if (rv < 0) {
 		goto out;
 	}
-	rv = sqsh_tree_walker_resolve(&walker, path, true);
+	rv = sqsh_path_resolver_resolve(&resolver, path, true);
 	if (rv == -SQSH_ERROR_NO_SUCH_FILE) {
 		rv = 0;
 		goto out;
@@ -66,7 +66,7 @@ sqsh_easy_file_exists(struct SqshArchive *archive, const char *path, int *err) {
 	exists = true;
 
 out:
-	sqsh__tree_walker_cleanup(&walker);
+	sqsh__path_resolver_cleanup(&resolver);
 	if (err != NULL) {
 		*err = rv;
 	}

--- a/lib/read/file/file.c
+++ b/lib/read/file/file.c
@@ -621,19 +621,19 @@ sqsh__file_cleanup(struct SqshFile *inode) {
 struct SqshFile *
 sqsh_open(struct SqshArchive *archive, const char *path, int *err) {
 	int rv;
-	struct SqshTreeWalker walker = {0};
+	struct SqshPathResolver resolver = {0};
 	struct SqshFile *inode = NULL;
-	rv = sqsh__tree_walker_init(&walker, archive);
+	rv = sqsh__path_resolver_init(&resolver, archive);
 	if (rv < 0) {
 		goto out;
 	}
 
-	rv = sqsh_tree_walker_resolve(&walker, path, true);
+	rv = sqsh_path_resolver_resolve(&resolver, path, true);
 	if (rv < 0) {
 		goto out;
 	}
 
-	inode = sqsh_tree_walker_open_file(&walker, &rv);
+	inode = sqsh_path_resolver_open_file(&resolver, &rv);
 	if (rv < 0) {
 		goto out;
 	}
@@ -642,7 +642,7 @@ out:
 	if (err != NULL) {
 		*err = rv;
 	}
-	sqsh__tree_walker_cleanup(&walker);
+	sqsh__path_resolver_cleanup(&resolver);
 	return inode;
 }
 

--- a/lib/read/meson.build
+++ b/lib/read/meson.build
@@ -37,6 +37,7 @@ libsqsh_sources = files(
     'table/table.c',
     'table/xattr_table.c',
     'tree/walker.c',
+    'tree/path_resolver.c',
     'utils/error.c',
     'utils/posix.c',
     'utils/thread.c',

--- a/lib/read/tree/path_resolver.c
+++ b/lib/read/tree/path_resolver.c
@@ -1,0 +1,403 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (c) 2023, Enno Boland <g@s01.de>                                 *
+ *                                                                            *
+ * Redistribution and use in source and binary forms, with or without         *
+ * modification, are permitted provided that the following conditions are     *
+ * met:                                                                       *
+ *                                                                            *
+ * * Redistributions of source code must retain the above copyright notice,   *
+ *   this list of conditions and the following disclaimer.                    *
+ * * Redistributions in binary form must reproduce the above copyright        *
+ *   notice, this list of conditions and the following disclaimer in the      *
+ *   documentation and/or other materials provided with the distribution.     *
+ *                                                                            *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS    *
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,  *
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR     *
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR          *
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,      *
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,        *
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR         *
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF     *
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING       *
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS         *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               *
+ *                                                                            *
+ ******************************************************************************/
+
+/**
+ * @author       Enno Boland (mail@eboland.de)
+ * @file         walker.c
+ */
+
+#include "../../../include/sqsh_tree_private.h"
+
+#include "../../../include/sqsh_archive_private.h"
+#include "../../../include/sqsh_directory_private.h"
+#include "../../../include/sqsh_error.h"
+#include "../../../include/sqsh_file_private.h"
+#include "../utils/utils.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#define SQSH_DEFAULT_MAX_SYMLINKS_FOLLOWED 100
+
+SQSH_NO_UNUSED static int path_resolve(
+		struct SqshPathResolver *walker, const char *path, size_t path_len,
+		int recursion);
+
+SQSH_NO_UNUSED static int
+update_inode_from_iterator(struct SqshPathResolver *walker) {
+	// TODO: this should be done from sqsh__file_init.
+	struct SqshDirectoryIterator *iterator = &walker->iterator;
+	uint32_t inode_number = sqsh_directory_iterator_inode(iterator);
+	uint64_t inode_ref = sqsh_directory_iterator_inode_ref(iterator);
+
+	walker->current_inode_ref = inode_ref;
+	return sqsh_inode_map_set2(walker->inode_map, inode_number, inode_ref);
+}
+
+SQSH_NO_UNUSED static int
+enter_directory(struct SqshPathResolver *walker, uint64_t inode_ref) {
+	int rv = 0;
+	struct SqshFile *cwd = &walker->cwd;
+	struct SqshDirectoryIterator *iterator = &walker->iterator;
+
+	rv = sqsh__file_cleanup(cwd);
+	if (rv < 0) {
+		goto out;
+	}
+
+	rv = sqsh__directory_iterator_cleanup(iterator);
+	if (rv < 0) {
+		goto out;
+	}
+
+	rv = sqsh__file_init(cwd, walker->archive, inode_ref);
+	if (rv < 0) {
+		goto out;
+	}
+
+	if (sqsh_file_type(cwd) != SQSH_FILE_TYPE_DIRECTORY) {
+		rv = -SQSH_ERROR_NOT_A_DIRECTORY;
+		goto out;
+	}
+
+	walker->begin_iterator = true;
+	rv = sqsh__directory_iterator_init(iterator, cwd);
+	if (rv < 0) {
+		goto out;
+	}
+
+	const uint64_t inode_number = sqsh_file_inode(cwd);
+	walker->current_inode_ref = inode_ref;
+	rv = sqsh_inode_map_set2(walker->inode_map, inode_number, inode_ref);
+
+out:
+	return rv;
+}
+
+int
+sqsh__path_resolver_init(
+		struct SqshPathResolver *walker, struct SqshArchive *archive) {
+	int rv = 0;
+	const struct SqshSuperblock *superblock = sqsh_archive_superblock(archive);
+	const struct SqshConfig *config = sqsh_archive_config(archive);
+
+	walker->max_symlink_depth = SQSH_CONFIG_DEFAULT(
+			config->max_symlink_depth, SQSH_DEFAULT_MAX_SYMLINKS_FOLLOWED);
+	walker->archive = archive;
+	walker->root_inode_ref = sqsh_superblock_inode_root_ref(superblock);
+	walker->begin_iterator = true;
+	rv = sqsh_archive_inode_map(archive, &walker->inode_map);
+	if (rv < 0) {
+		goto out;
+	}
+	rv = enter_directory(walker, walker->root_inode_ref);
+
+out:
+	return rv;
+}
+
+struct SqshPathResolver *
+sqsh_path_resolver_new(struct SqshArchive *archive, int *err) {
+	SQSH_NEW_IMPL(sqsh__path_resolver_init, struct SqshPathResolver, archive);
+}
+
+int
+sqsh_path_resolver_up(struct SqshPathResolver *walker) {
+	int rv = 0;
+	const struct SqshFile *cwd = &walker->cwd;
+	/* We do not use the parent inode to check if it is the root node.
+	 * According to the documentationen it *should* be zero. That's vague.
+	 */
+
+	if (sqsh_file_inode_ref(cwd) == walker->root_inode_ref) {
+		return -SQSH_ERROR_WALKER_CANNOT_GO_UP;
+	}
+	const uint64_t parent_inode = sqsh_file_directory_parent_inode(cwd);
+	if (parent_inode <= 0) {
+		rv = -SQSH_ERROR_CORRUPTED_INODE;
+		goto out;
+	}
+
+	const uint64_t parent_inode_ref =
+			sqsh_inode_map_get2(walker->inode_map, parent_inode, &rv);
+	if (rv < 0) {
+		goto out;
+	}
+
+	rv = enter_directory(walker, parent_inode_ref);
+	if (rv < 0) {
+		goto out;
+	}
+
+out:
+	return rv;
+}
+
+bool
+sqsh_path_resolver_next(struct SqshPathResolver *walker, int *err) {
+	struct SqshDirectoryIterator *iterator = &walker->iterator;
+	int rv = 0;
+	walker->begin_iterator = false;
+
+	bool has_next = sqsh_directory_iterator_next(iterator, &rv);
+	if (rv < 0) {
+		goto out;
+	}
+	if (has_next != false) {
+		rv = update_inode_from_iterator(walker);
+		if (rv < 0) {
+			goto out;
+		}
+	}
+
+out:
+	if (err != NULL) {
+		*err = rv;
+	}
+	if (rv < 0) {
+		return false;
+	} else {
+		return has_next;
+	}
+}
+
+enum SqshFileType
+sqsh_path_resolver_type(const struct SqshPathResolver *walker) {
+	if (walker->begin_iterator == true) {
+		return sqsh_file_type(&walker->cwd);
+	} else {
+		return sqsh_directory_iterator_file_type(&walker->iterator);
+	}
+}
+
+const char *
+sqsh_path_resolver_name(const struct SqshPathResolver *walker) {
+	if (walker->begin_iterator == true) {
+		return NULL;
+	} else {
+		return sqsh_directory_iterator_name(&walker->iterator);
+	}
+}
+
+uint16_t
+sqsh_path_resolver_name_size(const struct SqshPathResolver *walker) {
+	if (walker->begin_iterator == true) {
+		return 0;
+	} else {
+		return sqsh_directory_iterator_name_size(&walker->iterator);
+	}
+}
+
+char *
+sqsh_path_resolver_name_dup(const struct SqshPathResolver *walker) {
+	if (walker->begin_iterator == true) {
+		return NULL;
+	} else {
+		return sqsh_directory_iterator_name_dup(&walker->iterator);
+	}
+}
+
+int
+sqsh_path_resolver_revert(struct SqshPathResolver *walker) {
+	struct SqshFile *inode = &walker->cwd;
+	struct SqshDirectoryIterator *iterator = &walker->iterator;
+
+	sqsh__directory_iterator_cleanup(iterator);
+	walker->begin_iterator = true;
+	return sqsh__directory_iterator_init(iterator, inode);
+}
+
+int
+sqsh_path_resolver_lookup(
+		struct SqshPathResolver *walker, const char *name,
+		const size_t name_size) {
+	int rv = 0;
+	struct SqshDirectoryIterator *iterator = &walker->iterator;
+	rv = sqsh_path_resolver_revert(walker);
+	if (rv < 0) {
+		return rv;
+	}
+	rv = sqsh_directory_iterator_lookup(iterator, name, name_size);
+	if (rv < 0) {
+		return rv;
+	}
+	walker->begin_iterator = false;
+
+	return update_inode_from_iterator(walker);
+}
+
+int
+sqsh_path_resolver_down(struct SqshPathResolver *walker) {
+	if (walker->begin_iterator == true) {
+		return -SQSH_ERROR_WALKER_CANNOT_GO_DOWN;
+	}
+	const uint64_t child_inode_ref =
+			sqsh_directory_iterator_inode_ref(&walker->iterator);
+
+	return enter_directory(walker, child_inode_ref);
+}
+
+int
+sqsh_path_resolver_to_root(struct SqshPathResolver *walker) {
+	return enter_directory(walker, walker->root_inode_ref);
+}
+
+struct SqshFile *
+sqsh_path_resolver_open_file(const struct SqshPathResolver *walker, int *err) {
+	return sqsh_open_by_ref(walker->archive, walker->current_inode_ref, err);
+}
+
+static size_t
+path_segment_len(const char *path, size_t path_len) {
+	sqsh_index_t len = 0;
+	for (; len < path_len && path[len] != '/'; len++) {
+	}
+	return len;
+}
+
+static const char *
+path_next_segment(const char *path, size_t path_len) {
+	sqsh_index_t current_segment_len = path_segment_len(path, path_len);
+	if (current_segment_len == path_len) {
+		return NULL;
+	} else {
+		return &path[current_segment_len] + 1;
+	}
+}
+
+static int
+path_resolver_follow_symlink(struct SqshPathResolver *walker, int recursion) {
+	struct SqshFile inode = {0};
+	int rv = 0;
+	// if symlinks_followed is smaller than zero, the caller intends to disable
+	// symlink following
+	if (recursion < 0) {
+		return 0;
+	}
+	if (recursion == 0) {
+		return -SQSH_ERROR_TOO_MANY_SYMLINKS_FOLLOWED;
+	}
+
+	rv = sqsh__file_init(&inode, walker->archive, walker->current_inode_ref);
+	if (rv < 0) {
+		goto out;
+	}
+
+	rv = sqsh_path_resolver_revert(walker);
+	if (rv < 0) {
+		goto out;
+	}
+
+	const char *symlink = sqsh_file_symlink(&inode);
+	size_t symlink_len = sqsh_file_symlink_size(&inode);
+	rv = path_resolve(walker, symlink, symlink_len, recursion - 1);
+
+out:
+	sqsh__file_cleanup(&inode);
+	return rv;
+}
+
+static int
+path_resolve(
+		struct SqshPathResolver *walker, const char *path, size_t path_len,
+		int recursion) {
+	int rv = 0;
+	const char *segment = path, *next_segment;
+	size_t remaining_path_len = path_len;
+	bool is_dir = true;
+	if (segment[0] == '/') {
+		rv = sqsh_path_resolver_to_root(walker);
+		if (rv < 0) {
+			goto out;
+		}
+	}
+
+	do {
+		const size_t segment_len =
+				path_segment_len(segment, remaining_path_len);
+		next_segment = path_next_segment(segment, remaining_path_len);
+		remaining_path_len -= segment_len + 1;
+		if (strncmp(".", segment, segment_len) == 0 || segment_len == 0) {
+			is_dir = true;
+			continue;
+		} else if (strncmp("..", segment, segment_len) == 0) {
+			is_dir = true;
+			rv = sqsh_path_resolver_up(walker);
+		} else {
+			rv = sqsh_path_resolver_lookup(walker, segment, segment_len);
+			if (rv < 0) {
+				goto out;
+			}
+			switch (sqsh_path_resolver_type(walker)) {
+			case SQSH_FILE_TYPE_SYMLINK:
+				rv = path_resolver_follow_symlink(walker, recursion);
+				if (rv < 0) {
+					goto out;
+				}
+				is_dir = sqsh_path_resolver_type(walker) ==
+						SQSH_FILE_TYPE_DIRECTORY;
+				break;
+			case SQSH_FILE_TYPE_DIRECTORY:
+				is_dir = true;
+				rv = sqsh_path_resolver_down(walker);
+				break;
+			default:
+				is_dir = false;
+				break;
+			}
+		}
+		if (rv < 0) {
+			goto out;
+		}
+	} while ((segment = next_segment) && is_dir);
+	if (segment != NULL && is_dir == false) {
+		rv = -SQSH_ERROR_NOT_A_DIRECTORY;
+	}
+
+out:
+	return rv;
+}
+
+int
+sqsh_path_resolver_resolve(
+		struct SqshPathResolver *walker, const char *path, bool follow_links) {
+	int recursion = follow_links ? (int)walker->max_symlink_depth : -1;
+	return path_resolve(walker, path, strlen(path), recursion);
+}
+
+int
+sqsh__path_resolver_cleanup(struct SqshPathResolver *walker) {
+	sqsh__file_cleanup(&walker->cwd);
+	sqsh__directory_iterator_cleanup(&walker->iterator);
+	return 0;
+}
+
+int
+sqsh_path_resolver_free(struct SqshPathResolver *walker) {
+	SQSH_FREE_IMPL(sqsh__path_resolver_cleanup, walker);
+}

--- a/lib/read/tree/walker.c
+++ b/lib/read/tree/walker.c
@@ -31,6 +31,8 @@
  * @file         walker.c
  */
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #include "../../../include/sqsh_tree_private.h"
 
 #include "../../../include/sqsh_archive_private.h"
@@ -44,370 +46,90 @@
 
 #define SQSH_DEFAULT_MAX_SYMLINKS_FOLLOWED 100
 
-SQSH_NO_UNUSED static int tree_walker_resolve(
-		struct SqshTreeWalker *walker, const char *path, size_t path_len,
-		int recursion);
-
-SQSH_NO_UNUSED int
-update_inode_from_iterator(struct SqshTreeWalker *walker) {
-	// TODO: this should be done from sqsh__file_init.
-	struct SqshDirectoryIterator *iterator = &walker->iterator;
-	uint32_t inode_number = sqsh_directory_iterator_inode(iterator);
-	uint64_t inode_ref = sqsh_directory_iterator_inode_ref(iterator);
-
-	walker->current_inode_ref = inode_ref;
-	return sqsh_inode_map_set2(walker->inode_map, inode_number, inode_ref);
-}
-
 static int
-enter_directory(struct SqshTreeWalker *walker, uint64_t inode_ref) {
-	int rv = 0;
-	struct SqshFile *cwd = &walker->cwd;
-	struct SqshDirectoryIterator *iterator = &walker->iterator;
-
-	rv = sqsh__file_cleanup(cwd);
-	if (rv < 0) {
-		goto out;
-	}
-
-	rv = sqsh__directory_iterator_cleanup(iterator);
-	if (rv < 0) {
-		goto out;
-	}
-
-	rv = sqsh__file_init(cwd, walker->archive, inode_ref);
-	if (rv < 0) {
-		goto out;
-	}
-
-	if (sqsh_file_type(cwd) != SQSH_FILE_TYPE_DIRECTORY) {
-		rv = -SQSH_ERROR_NOT_A_DIRECTORY;
-		goto out;
-	}
-
-	walker->begin_iterator = true;
-	rv = sqsh__directory_iterator_init(iterator, cwd);
-	if (rv < 0) {
-		goto out;
-	}
-
-	const uint64_t inode_number = sqsh_file_inode(cwd);
-	walker->current_inode_ref = inode_ref;
-	rv = sqsh_inode_map_set2(walker->inode_map, inode_number, inode_ref);
-
-out:
-	return rv;
-}
-
-int
-sqsh__tree_walker_init(
-		struct SqshTreeWalker *walker, struct SqshArchive *archive) {
-	int rv = 0;
-	const struct SqshSuperblock *superblock = sqsh_archive_superblock(archive);
-	const struct SqshConfig *config = sqsh_archive_config(archive);
-
-	walker->max_symlink_depth = SQSH_CONFIG_DEFAULT(
-			config->max_symlink_depth, SQSH_DEFAULT_MAX_SYMLINKS_FOLLOWED);
-	walker->archive = archive;
-	walker->root_inode_ref = sqsh_superblock_inode_root_ref(superblock);
-	walker->begin_iterator = true;
-	rv = sqsh_archive_inode_map(archive, &walker->inode_map);
-	if (rv < 0) {
-		goto out;
-	}
-	rv = enter_directory(walker, walker->root_inode_ref);
-
-out:
-	return rv;
+tree_walker_init(struct SqshTreeWalker *walker, struct SqshArchive *archive) {
+	return sqsh__path_resolver_init(&walker->inner, archive);
 }
 
 struct SqshTreeWalker *
 sqsh_tree_walker_new(struct SqshArchive *archive, int *err) {
-	SQSH_NEW_IMPL(sqsh__tree_walker_init, struct SqshTreeWalker, archive);
+	SQSH_NEW_IMPL(tree_walker_init, struct SqshTreeWalker, archive);
 }
 
 int
 sqsh_tree_walker_up(struct SqshTreeWalker *walker) {
-	int rv = 0;
-	const struct SqshFile *cwd = &walker->cwd;
-	/* We do not use the parent inode to check if it is the root node.
-	 * According to the documentationen it *should* be zero. That's vague.
-	 */
-
-	if (sqsh_file_inode_ref(cwd) == walker->root_inode_ref) {
-		return -SQSH_ERROR_WALKER_CANNOT_GO_UP;
-	}
-	const uint64_t parent_inode = sqsh_file_directory_parent_inode(cwd);
-	if (parent_inode <= 0) {
-		rv = -SQSH_ERROR_CORRUPTED_INODE;
-		goto out;
-	}
-
-	const uint64_t parent_inode_ref =
-			sqsh_inode_map_get2(walker->inode_map, parent_inode, &rv);
-	if (rv < 0) {
-		goto out;
-	}
-
-	rv = enter_directory(walker, parent_inode_ref);
-	if (rv < 0) {
-		goto out;
-	}
-
-out:
-	return rv;
+	return sqsh_path_resolver_up(&walker->inner);
 }
 
 int
 sqsh_tree_walker_next(struct SqshTreeWalker *walker) {
 	int rv = 0;
-	bool has_next = sqsh_tree_walker_next2(walker, &rv);
+	bool has_next = sqsh_path_resolver_next(&walker->inner, &rv);
 	if (rv < 0) {
 		return rv;
 	}
 	return has_next ? 1 : 0;
 }
 
-bool
-sqsh_tree_walker_next2(struct SqshTreeWalker *walker, int *err) {
-	struct SqshDirectoryIterator *iterator = &walker->iterator;
-	int rv = 0;
-	walker->begin_iterator = false;
-
-	bool has_next = sqsh_directory_iterator_next(iterator, &rv);
-	if (rv < 0) {
-		goto out;
-	}
-	if (has_next != false) {
-		rv = update_inode_from_iterator(walker);
-		if (rv < 0) {
-			goto out;
-		}
-	}
-
-out:
-	if (err != NULL) {
-		*err = rv;
-	}
-	if (rv < 0) {
-		return false;
-	} else {
-		return has_next;
-	}
-}
-
 enum SqshFileType
 sqsh_tree_walker_type(const struct SqshTreeWalker *walker) {
-	if (walker->begin_iterator == true) {
-		return sqsh_file_type(&walker->cwd);
-	} else {
-		return sqsh_directory_iterator_file_type(&walker->iterator);
-	}
+	return sqsh_path_resolver_type(&walker->inner);
 }
 
 const char *
 sqsh_tree_walker_name(const struct SqshTreeWalker *walker) {
-	if (walker->begin_iterator == true) {
-		return NULL;
-	} else {
-		return sqsh_directory_iterator_name(&walker->iterator);
-	}
+	return sqsh_path_resolver_name(&walker->inner);
 }
 
 uint16_t
 sqsh_tree_walker_name_size(const struct SqshTreeWalker *walker) {
-	if (walker->begin_iterator == true) {
-		return 0;
-	} else {
-		return sqsh_directory_iterator_name_size(&walker->iterator);
-	}
+	return sqsh_path_resolver_name_size(&walker->inner);
 }
 
 char *
 sqsh_tree_walker_name_dup(const struct SqshTreeWalker *walker) {
-	if (walker->begin_iterator == true) {
-		return NULL;
-	} else {
-		return sqsh_directory_iterator_name_dup(&walker->iterator);
-	}
+	return sqsh_path_resolver_name_dup(&walker->inner);
 }
 
 int
 sqsh_tree_walker_revert(struct SqshTreeWalker *walker) {
-	struct SqshFile *inode = &walker->cwd;
-	struct SqshDirectoryIterator *iterator = &walker->iterator;
-
-	sqsh__directory_iterator_cleanup(iterator);
-	walker->begin_iterator = true;
-	return sqsh__directory_iterator_init(iterator, inode);
+	return sqsh_path_resolver_revert(&walker->inner);
 }
 
 int
 sqsh_tree_walker_lookup(
 		struct SqshTreeWalker *walker, const char *name,
 		const size_t name_size) {
-	int rv = 0;
-	struct SqshDirectoryIterator *iterator = &walker->iterator;
-	rv = sqsh_tree_walker_revert(walker);
-	if (rv < 0) {
-		return rv;
-	}
-	rv = sqsh_directory_iterator_lookup(iterator, name, name_size);
-	if (rv < 0) {
-		return rv;
-	}
-	walker->begin_iterator = false;
-
-	return update_inode_from_iterator(walker);
+	return sqsh_path_resolver_lookup(&walker->inner, name, name_size);
 }
 
 int
 sqsh_tree_walker_down(struct SqshTreeWalker *walker) {
-	if (walker->begin_iterator == true) {
-		return -SQSH_ERROR_WALKER_CANNOT_GO_DOWN;
-	}
-	const uint64_t child_inode_ref =
-			sqsh_directory_iterator_inode_ref(&walker->iterator);
-
-	return enter_directory(walker, child_inode_ref);
+	return sqsh_path_resolver_down(&walker->inner);
 }
 
 int
 sqsh_tree_walker_to_root(struct SqshTreeWalker *walker) {
-	return enter_directory(walker, walker->root_inode_ref);
+	return sqsh_path_resolver_to_root(&walker->inner);
 }
 
 struct SqshFile *
 sqsh_tree_walker_open_file(const struct SqshTreeWalker *walker, int *err) {
-	return sqsh_open_by_ref(walker->archive, walker->current_inode_ref, err);
-}
-
-size_t
-path_segment_len(const char *path, size_t path_len) {
-	sqsh_index_t len = 0;
-	for (; len < path_len && path[len] != '/'; len++) {
-	}
-	return len;
-}
-
-static const char *
-path_next_segment(const char *path, size_t path_len) {
-	sqsh_index_t current_segment_len = path_segment_len(path, path_len);
-	if (current_segment_len == path_len) {
-		return NULL;
-	} else {
-		return &path[current_segment_len] + 1;
-	}
-}
-
-static int
-tree_walker_follow_symlink(struct SqshTreeWalker *walker, int recursion) {
-	struct SqshFile inode = {0};
-	int rv = 0;
-	// if symlinks_followed is smaller than zero, the caller intends to disable
-	// symlink following
-	if (recursion < 0) {
-		return 0;
-	}
-	if (recursion == 0) {
-		return -SQSH_ERROR_TOO_MANY_SYMLINKS_FOLLOWED;
-	}
-
-	rv = sqsh__file_init(&inode, walker->archive, walker->current_inode_ref);
-	if (rv < 0) {
-		goto out;
-	}
-
-	rv = sqsh_tree_walker_revert(walker);
-	if (rv < 0) {
-		goto out;
-	}
-
-	const char *symlink = sqsh_file_symlink(&inode);
-	size_t symlink_len = sqsh_file_symlink_size(&inode);
-	rv = tree_walker_resolve(walker, symlink, symlink_len, recursion - 1);
-
-out:
-	sqsh__file_cleanup(&inode);
-	return rv;
-}
-
-static int
-tree_walker_resolve(
-		struct SqshTreeWalker *walker, const char *path, size_t path_len,
-		int recursion) {
-	int rv = 0;
-	const char *segment = path, *next_segment;
-	size_t remaining_path_len = path_len;
-	bool is_dir = true;
-	if (segment[0] == '/') {
-		rv = sqsh_tree_walker_to_root(walker);
-		if (rv < 0) {
-			goto out;
-		}
-	}
-
-	do {
-		const size_t segment_len =
-				path_segment_len(segment, remaining_path_len);
-		next_segment = path_next_segment(segment, remaining_path_len);
-		remaining_path_len -= segment_len + 1;
-		if (strncmp(".", segment, segment_len) == 0 || segment_len == 0) {
-			is_dir = true;
-			continue;
-		} else if (strncmp("..", segment, segment_len) == 0) {
-			is_dir = true;
-			rv = sqsh_tree_walker_up(walker);
-		} else {
-			rv = sqsh_tree_walker_lookup(walker, segment, segment_len);
-			if (rv < 0) {
-				goto out;
-			}
-			switch (sqsh_tree_walker_type(walker)) {
-			case SQSH_FILE_TYPE_SYMLINK:
-				rv = tree_walker_follow_symlink(walker, recursion);
-				if (rv < 0) {
-					goto out;
-				}
-				is_dir = sqsh_tree_walker_type(walker) ==
-						SQSH_FILE_TYPE_DIRECTORY;
-				break;
-			case SQSH_FILE_TYPE_DIRECTORY:
-				is_dir = true;
-				rv = sqsh_tree_walker_down(walker);
-				break;
-			default:
-				is_dir = false;
-				break;
-			}
-		}
-		if (rv < 0) {
-			goto out;
-		}
-	} while ((segment = next_segment) && is_dir);
-	if (segment != NULL && is_dir == false) {
-		rv = -SQSH_ERROR_NOT_A_DIRECTORY;
-	}
-
-out:
-	return rv;
+	return sqsh_path_resolver_open_file(&walker->inner, err);
 }
 
 int
 sqsh_tree_walker_resolve(
 		struct SqshTreeWalker *walker, const char *path, bool follow_links) {
-	int recursion = follow_links ? (int)walker->max_symlink_depth : -1;
-	return tree_walker_resolve(walker, path, strlen(path), recursion);
+	return sqsh_path_resolver_resolve(&walker->inner, path, follow_links);
 }
 
-int
-sqsh__tree_walker_cleanup(struct SqshTreeWalker *walker) {
-	sqsh__file_cleanup(&walker->cwd);
-	sqsh__directory_iterator_cleanup(&walker->iterator);
-	return 0;
+static int
+tree_walker_cleanup(struct SqshTreeWalker *walker) {
+	return sqsh__path_resolver_cleanup(&walker->inner);
 }
 
 int
 sqsh_tree_walker_free(struct SqshTreeWalker *walker) {
-	SQSH_FREE_IMPL(sqsh__tree_walker_cleanup, walker);
+	SQSH_FREE_IMPL(tree_walker_cleanup, walker);
 }

--- a/test/integration.c
+++ b/test/integration.c
@@ -60,20 +60,20 @@ static void
 sqsh_get_nonexistant(void) {
 	int rv;
 	struct SqshArchive sqsh = {0};
-	struct SqshTreeWalker walker = {0};
+	struct SqshPathResolver resolver = {0};
 
 	struct SqshConfig config = DEFAULT_CONFIG(TEST_SQUASHFS_IMAGE_LEN);
 	config.archive_offset = 1010;
 	rv = sqsh__archive_init(&sqsh, (char *)TEST_SQUASHFS_IMAGE, &config);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_init(&walker, &sqsh);
+	rv = sqsh__path_resolver_init(&resolver, &sqsh);
 	assert(rv == 0);
 
-	rv = sqsh_tree_walker_resolve(&walker, "/nonexistant", false);
+	rv = sqsh_path_resolver_resolve(&resolver, "/nonexistant", false);
 	assert(rv < 0);
 
-	rv = sqsh__tree_walker_cleanup(&walker);
+	rv = sqsh__path_resolver_cleanup(&resolver);
 	assert(rv == 0);
 
 	rv = sqsh__archive_cleanup(&sqsh);
@@ -81,9 +81,9 @@ sqsh_get_nonexistant(void) {
 }
 
 static void
-tree_walker(void) {
+path_resolver(void) {
 	int rv;
-	struct SqshTreeWalker walker = {0};
+	struct SqshPathResolver resolver = {0};
 	struct SqshArchive sqsh = {0};
 	struct SqshFile *file;
 	struct SqshConfig config = DEFAULT_CONFIG(TEST_SQUASHFS_IMAGE_LEN);
@@ -91,23 +91,23 @@ tree_walker(void) {
 	rv = sqsh__archive_init(&sqsh, (char *)TEST_SQUASHFS_IMAGE, &config);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_init(&walker, &sqsh);
+	rv = sqsh__path_resolver_init(&resolver, &sqsh);
 	assert(rv == 0);
 
-	rv = sqsh_tree_walker_resolve(&walker, "/large_dir", false);
+	rv = sqsh_path_resolver_resolve(&resolver, "/large_dir", false);
 	assert(rv == 0);
 
-	rv = sqsh_tree_walker_resolve(&walker, "999", false);
+	rv = sqsh_path_resolver_resolve(&resolver, "999", false);
 	assert(rv == 0);
 
-	file = sqsh_tree_walker_open_file(&walker, &rv);
+	file = sqsh_path_resolver_open_file(&resolver, &rv);
 	assert(file != NULL);
 	assert(rv == 0);
 
 	rv = sqsh_close(file);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_cleanup(&walker);
+	rv = sqsh__path_resolver_cleanup(&resolver);
 	assert(rv == 0);
 
 	rv = sqsh__archive_cleanup(&sqsh);
@@ -201,19 +201,19 @@ sqsh_cat_fragment(void) {
 	struct SqshFile *file = NULL;
 	struct SqshFileReader reader = {0};
 	struct SqshArchive sqsh = {0};
-	struct SqshTreeWalker walker = {0};
+	struct SqshPathResolver resolver = {0};
 	struct SqshConfig config = DEFAULT_CONFIG(TEST_SQUASHFS_IMAGE_LEN);
 	config.archive_offset = 1010;
 	rv = sqsh__archive_init(&sqsh, (char *)TEST_SQUASHFS_IMAGE, &config);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_init(&walker, &sqsh);
+	rv = sqsh__path_resolver_init(&resolver, &sqsh);
 	assert(rv == 0);
 
-	rv = sqsh_tree_walker_resolve(&walker, "a", false);
+	rv = sqsh_path_resolver_resolve(&resolver, "a", false);
 	assert(rv == 0);
 
-	file = sqsh_tree_walker_open_file(&walker, &rv);
+	file = sqsh_path_resolver_open_file(&resolver, &rv);
 	assert(file != NULL);
 	assert(rv == 0);
 
@@ -235,7 +235,7 @@ sqsh_cat_fragment(void) {
 	rv = sqsh_close(file);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_cleanup(&walker);
+	rv = sqsh__path_resolver_cleanup(&resolver);
 	assert(rv == 0);
 
 	rv = sqsh__archive_cleanup(&sqsh);
@@ -250,7 +250,7 @@ sqsh_cat_datablock_and_fragment(void) {
 	struct SqshFile *file = NULL;
 	struct SqshFileReader reader = {0};
 	struct SqshArchive sqsh = {0};
-	struct SqshTreeWalker walker = {0};
+	struct SqshPathResolver resolver = {0};
 	const struct SqshConfig config = {
 			.source_mapper = sqsh_mapper_impl_static,
 			.source_size = TEST_SQUASHFS_IMAGE_LEN,
@@ -259,13 +259,13 @@ sqsh_cat_datablock_and_fragment(void) {
 	rv = sqsh__archive_init(&sqsh, (char *)TEST_SQUASHFS_IMAGE, &config);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_init(&walker, &sqsh);
+	rv = sqsh__path_resolver_init(&resolver, &sqsh);
 	assert(rv == 0);
 
-	rv = sqsh_tree_walker_resolve(&walker, "b", false);
+	rv = sqsh_path_resolver_resolve(&resolver, "b", false);
 	assert(rv == 0);
 
-	file = sqsh_tree_walker_open_file(&walker, &rv);
+	file = sqsh_path_resolver_open_file(&resolver, &rv);
 	assert(file != NULL);
 	assert(rv == 0);
 
@@ -290,7 +290,7 @@ sqsh_cat_datablock_and_fragment(void) {
 	rv = sqsh_close(file);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_cleanup(&walker);
+	rv = sqsh__path_resolver_cleanup(&resolver);
 	assert(rv == 0);
 
 	rv = sqsh__archive_cleanup(&sqsh);
@@ -304,7 +304,7 @@ sqsh_cat_size_overflow(void) {
 	struct SqshFile *file = NULL;
 	struct SqshFileReader reader = {0};
 	struct SqshArchive sqsh = {0};
-	struct SqshTreeWalker walker = {0};
+	struct SqshPathResolver resolver = {0};
 	const struct SqshConfig config = {
 			.source_mapper = sqsh_mapper_impl_static,
 			.source_size = TEST_SQUASHFS_IMAGE_LEN,
@@ -313,13 +313,13 @@ sqsh_cat_size_overflow(void) {
 	rv = sqsh__archive_init(&sqsh, (char *)TEST_SQUASHFS_IMAGE, &config);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_init(&walker, &sqsh);
+	rv = sqsh__path_resolver_init(&resolver, &sqsh);
 	assert(rv == 0);
 
-	rv = sqsh_tree_walker_resolve(&walker, "b", false);
+	rv = sqsh_path_resolver_resolve(&resolver, "b", false);
 	assert(rv == 0);
 
-	file = sqsh_tree_walker_open_file(&walker, &rv);
+	file = sqsh_path_resolver_open_file(&resolver, &rv);
 	assert(file != NULL);
 	assert(rv == 0);
 
@@ -337,7 +337,7 @@ sqsh_cat_size_overflow(void) {
 	rv = sqsh_close(file);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_cleanup(&walker);
+	rv = sqsh__path_resolver_cleanup(&resolver);
 	assert(rv == 0);
 
 	rv = sqsh__archive_cleanup(&sqsh);
@@ -381,7 +381,7 @@ sqsh_test_extended_dir(void) {
 	int rv;
 	struct SqshFile *file = NULL;
 	struct SqshArchive sqsh = {0};
-	struct SqshTreeWalker walker = {0};
+	struct SqshPathResolver resolver = {0};
 	const struct SqshConfig config = {
 			.source_mapper = sqsh_mapper_impl_static,
 			.source_size = TEST_SQUASHFS_IMAGE_LEN,
@@ -390,19 +390,19 @@ sqsh_test_extended_dir(void) {
 	rv = sqsh__archive_init(&sqsh, (char *)TEST_SQUASHFS_IMAGE, &config);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_init(&walker, &sqsh);
+	rv = sqsh__path_resolver_init(&resolver, &sqsh);
 	assert(rv == 0);
 
-	rv = sqsh_tree_walker_resolve(&walker, "/large_dir/999", false);
+	rv = sqsh_path_resolver_resolve(&resolver, "/large_dir/999", false);
 	assert(rv == 0);
 
-	file = sqsh_tree_walker_open_file(&walker, &rv);
+	file = sqsh_path_resolver_open_file(&resolver, &rv);
 	assert(file != NULL);
 
 	rv = sqsh_close(file);
 	assert(rv == 0);
 
-	rv = sqsh__tree_walker_cleanup(&walker);
+	rv = sqsh__path_resolver_cleanup(&resolver);
 
 	rv = sqsh__archive_cleanup(&sqsh);
 	assert(rv == 0);
@@ -520,21 +520,21 @@ struct Walker {
 };
 
 static void *
-multithreaded_walker(void *arg) {
+multithreaded_resolver(void *arg) {
 	int rv;
-	struct Walker *walker = arg;
-	struct Walker my_walker = {
-			.sqsh = walker->sqsh,
+	struct Walker *resolver = arg;
+	struct Walker my_resolver = {
+			.sqsh = resolver->sqsh,
 	};
 
 	struct SqshFile *file =
-			sqsh_open_by_ref(walker->sqsh, walker->inode_number, &rv);
+			sqsh_open_by_ref(resolver->sqsh, resolver->inode_number, &rv);
 
 	if (sqsh_file_type(file) == SQSH_FILE_TYPE_DIRECTORY) {
 		struct SqshDirectoryIterator *iter =
 				sqsh_directory_iterator_new(file, &rv);
 		while (sqsh_directory_iterator_next(iter, &rv) > 0) {
-			multithreaded_walker(&my_walker);
+			multithreaded_resolver(&my_resolver);
 		}
 		sqsh_directory_iterator_free(iter);
 	} else {
@@ -561,12 +561,13 @@ multithreaded(void) {
 	assert(rv == 0);
 
 	const struct SqshSuperblock *superblock = sqsh_archive_superblock(&sqsh);
-	struct Walker walker = {
+	struct Walker resolver = {
 			.sqsh = &sqsh,
 			.inode_number = sqsh_superblock_inode_root_ref(superblock),
 	};
 	for (unsigned long i = 0; i < LENGTH(threads); i++) {
-		rv = pthread_create(&threads[i], NULL, multithreaded_walker, &walker);
+		rv = pthread_create(
+				&threads[i], NULL, multithreaded_resolver, &resolver);
 		assert(rv == 0);
 	}
 
@@ -605,7 +606,7 @@ test_follow_symlink(void) {
 DECLARE_TESTS
 TEST(sqsh_empty)
 TEST(sqsh_ls)
-TEST(tree_walker)
+TEST(path_resolver)
 TEST(sqsh_get_nonexistant)
 TEST(sqsh_read_content)
 TEST(sqsh_cat_fragment)

--- a/test/meson.build
+++ b/test/meson.build
@@ -32,6 +32,7 @@ sqsh_test = [
     'nasty.c',
     'reader/reader.c',
     'tree/walker.c',
+    'tree/path_resolver.c',
     'xattr/xattr_iterator.c',
 ]
 sqsh_extended_test = [

--- a/tools/unpack.c
+++ b/tools/unpack.c
@@ -335,7 +335,7 @@ main(int argc, char *argv[]) {
 	char *src_path = "/";
 	char *target_path = NULL;
 	struct SqshArchive *sqsh;
-	struct SqshTreeWalker *walker = NULL;
+	struct SqshPathResolver *resolver = NULL;
 	struct SqshFile *file = NULL;
 	uint64_t offset = 0;
 
@@ -377,20 +377,20 @@ main(int argc, char *argv[]) {
 		rv = EXIT_FAILURE;
 		goto out;
 	}
-	walker = sqsh_tree_walker_new(sqsh, &rv);
+	resolver = sqsh_path_resolver_new(sqsh, &rv);
 	if (rv < 0) {
 		sqsh_perror(rv, image_path);
 		rv = EXIT_FAILURE;
 		goto out;
 	}
 
-	rv = sqsh_tree_walker_resolve(walker, src_path, false);
+	rv = sqsh_path_resolver_resolve(resolver, src_path, false);
 	if (rv < 0) {
 		sqsh_perror(rv, src_path);
 		rv = EXIT_FAILURE;
 		goto out;
 	}
-	file = sqsh_tree_walker_open_file(walker, &rv);
+	file = sqsh_path_resolver_open_file(resolver, &rv);
 	if (rv < 0) {
 		sqsh_perror(rv, src_path);
 		rv = EXIT_FAILURE;
@@ -431,7 +431,7 @@ main(int argc, char *argv[]) {
 	}
 out:
 	sqsh_close(file);
-	sqsh_tree_walker_free(walker);
+	sqsh_path_resolver_free(resolver);
 	sqsh_archive_close(sqsh);
 	return rv;
 }


### PR DESCRIPTION
This change renames the tree walker to path resolver. This is done to better reflect the purpose of the struct and avoid misuse.