### PR TITLE
metablock_iterator: fix memory leak

### DIFF
--- a/lib/read/metablock/metablock_iterator.c
+++ b/lib/read/metablock/metablock_iterator.c
@@ -110,6 +110,7 @@ map_data(struct SqshMetablockIterator *iterator) {
 		goto out;
 	}
 
+	sqsh__extract_view_cleanup(&iterator->extract_view);
 	if (iterator->is_compressed) {
 		rv = sqsh__extract_view_init(
 				&iterator->extract_view, iterator->compression_manager,
@@ -132,8 +133,6 @@ bool
 sqsh__metablock_iterator_next(
 		struct SqshMetablockIterator *iterator, int *err) {
 	int rv = 0;
-
-	sqsh__extract_view_cleanup(&iterator->extract_view);
 
 	rv = process_next_header(iterator);
 	if (rv < 0) {

--- a/test/meson.build
+++ b/test/meson.build
@@ -42,6 +42,7 @@ sqsh_extended_test = [
     'tools/read-chunk/tail.sh',
     'tools/unpack/repack.sh',
     'tools/unpack/pathtraversal/pathtraversal.sh',
+    'tools/ls/large-tree.sh',
 ]
 sqsh_extended_fs_test = [
     'tools/fs/large-file.sh',

--- a/test/tools/ls/large-tree.sh
+++ b/test/tools/ls/large-tree.sh
@@ -1,0 +1,34 @@
+#!/bin/sh -ex
+
+######################################################################
+# @author      : Enno Boland (mail@eboland.de)
+# @file        : repack.sh
+# @created     : Friday Mar 17, 2023 15:11:09 CET
+#
+# @description : This script creates a squashfs image, mounts it, and
+#                repacks it from the mounted path.
+######################################################################
+
+: "${BUILD_DIR:?BUILD_DIR is not set}"
+: "${MKSQUASHFS:?MKSQUASHFS is not set}"
+: "${SOURCE_ROOT:?SOURCE_ROOT is not set}"
+: "${SQSH_LS:?SQSH_UNPACK is not set}"
+
+MKSQUASHFS_OPTS="-no-xattrs -noappend -all-root -mkfs-time 0"
+
+WORK_DIR="$BUILD_DIR/unpack-repack"
+
+mkdir -p "$WORK_DIR"
+cd "$WORK_DIR"
+
+mkdir -p "$PWD/empty"
+
+for i in $(seq 1 3641); do
+  echo "dir$i d 777 0 0";
+  echo "dir$i/file c 776 0 0 100 1";
+done > "$PWD/large_tree.pseudo";
+
+# shellcheck disable=SC2086
+$MKSQUASHFS "$PWD/empty" "$PWD/large_tree.squashfs" -pf "$PWD/large_tree.pseudo" \
+	$MKSQUASHFS_OPTS
+exec $SQSH_LS -r "$PWD/large_tree.squashfs"


### PR DESCRIPTION
`extract_view` was not cleaned up properly when the iterator used the _skip() method. This caused a memory leak.

This change cleans up `extract_view` right before it is (re-)initialized. Also it adds a integration test that checks for this issue.