### PR TITLE
tools: support longopts

### DIFF
--- a/tools/man/sqsh-cat.1.in
+++ b/tools/man/sqsh-cat.1.in
@@ -27,11 +27,11 @@ output.
 
 .SH OPTIONS
 .TP
-.BR \-o " " \fIOFFSET\fR
+.BR \-o " " \fIOFFSET\fR ", " \-\-offset " " \fIOFFSET\fR
 skip OFFSET bytes at start of FILESYSTEM.
 
 .TP
-.BR \-v
+.BR \-v ", " \-\-version
 Print the version of \fBsqsh-cat\fR and exit.
 
 .SH ARGUMENTS

--- a/tools/man/sqsh-ls.1.in
+++ b/tools/man/sqsh-ls.1.in
@@ -24,21 +24,21 @@ within the archive.
 
 .SH OPTIONS
 .TP
-.BR \-o " " \fIOFFSET\fR
+.BR \-o " " \fIOFFSET\fR ", " \fB\-\-offset " " \fIOFFSET\fR
 skip OFFSET bytes at start of FILESYSTEM.
 
 .TP
-.BR \-r
+.BR \-r ", " \fB\-\-recursive
 Recursively list the contents of all subdirectories within the 
 specified path.
 
 .TP
-.BR \-l
+.BR \-l ", " \fB\-\-long
 Print a long format listing of files and directories, similar to the 
 output of the \fBls -l\fR command.
 
 .TP
-.BR \-v
+.BR \-v ", " \fB\-\-version
 Print the version of \fBsqsh-ls\fR and exit.
 
 .SH ARGUMENTS

--- a/tools/man/sqsh-stat.1.in
+++ b/tools/man/sqsh-stat.1.in
@@ -29,11 +29,11 @@ type.
 
 .SH OPTIONS
 .TP
-.BR \-o " " \fIOFFSET\fR
+.BR \-o " " \fIOFFSET\fR ", " \-\-offset " " \fIOFFSET\fR
 skip OFFSET bytes at start of FILESYSTEM.
 
 .TP
-.BR \-v
+.BR \-v ", " \-\-version
 Print the version of \fBsqsh-stat\fR and exit.
 
 .SH ARGUMENTS
@@ -62,8 +62,7 @@ archive:
 
 To display information about multiple paths within the squashfs archive:
 
-.BR sqsh-stat " " /path/to/filesystem.sqsh " " /path/to/file1 
-/path/to/directory/
+.BR sqsh-stat " " /path/to/filesystem.sqsh " " /path/to/file1 " "/path/to/dir/
 
 To print the version of \fBsqsh-stat\fR:
 

--- a/tools/man/sqsh-unpack.1.in
+++ b/tools/man/sqsh-unpack.1.in
@@ -26,16 +26,20 @@ the archive.
 
 .SH OPTIONS
 .TP
-.BR \-o " " \fIOFFSET\fR
+.BR \-v ", " \-\-version
+Print the version of \fBsqsh-stat\fR and exit.
+
+.TP
+.BR \-o " " \fIOFFSET\fR ", " \fB\-\-offset " " \fIOFFSET\fR
 skip OFFSET bytes at start of FILESYSTEM.
 
 .TP
-.BR \-c
+.BR \-c ", " \fB\-\-chown\fR
 Change the owner and group of extracted files to match the user and 
 group ID of the current user.
 
 .TP
-.BR \-V
+.BR \-V ", " \fB\-\-verbose\fR
 Print more verbose output during unpacking.
 
 .SH ARGUMENTS

--- a/tools/man/sqsh-xattr.1.in
+++ b/tools/man/sqsh-xattr.1.in
@@ -17,12 +17,12 @@ The command operates in read-only mode.
 
 .SH OPTIONS
 .TP
-.BR \-v
-Print the version of \fBsqsh-xattr\fR.
+.BR \-v ", " \-\-version
+Print the version of \fBsqsh-xattr\fR and exit.
 
 .SH ARGUMENTS
 .TP
-.BR \-o " " \fIOFFSET\fR
+.BR \-o " " \fIOFFSET\fR ", " \-\-offset " " \fIOFFSET\fR
 skip OFFSET bytes at start of FILESYSTEM.
 
 .TP

--- a/tools/src/cat.c
+++ b/tools/src/cat.c
@@ -71,6 +71,14 @@ out:
 	return rv;
 }
 
+static const char opts[] = "o:vh";
+static const struct option long_opts[] = {
+		{"offset", required_argument, NULL, 'o'},
+		{"version", no_argument, NULL, 'v'},
+		{"help", no_argument, NULL, 'h'},
+		{0},
+};
+
 int
 main(int argc, char *argv[]) {
 	int rv = 0;
@@ -79,7 +87,7 @@ main(int argc, char *argv[]) {
 	struct SqshArchive *sqsh = NULL;
 	uint64_t offset = 0;
 
-	while ((opt = getopt(argc, argv, "o:vh")) != -1) {
+	while ((opt = getopt_long(argc, argv, opts, long_opts, NULL)) != -1) {
 		switch (opt) {
 		case 'o':
 			offset = strtoull(optarg, NULL, 0);

--- a/tools/src/common.h
+++ b/tools/src/common.h
@@ -7,12 +7,11 @@
 
 #define TOOLS_COMMON_H
 
-#ifndef _DEFAULT_SOURCE
-#	define _DEFAULT_SOURCE
-#endif
+#define _GNU_SOURCE
 
-#include "../include/sqsh.h"
 #include <ctype.h>
+#include <getopt.h>
+#include <sqsh.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/tools/src/ls.c
+++ b/tools/src/ls.c
@@ -253,6 +253,16 @@ out:
 	return rv;
 }
 
+static const char opts[] = "o:vrhl";
+static const struct option long_opts[] = {
+		{"offset", required_argument, NULL, 'o'},
+		{"version", no_argument, NULL, 'v'},
+		{"recursive", no_argument, NULL, 'r'},
+		{"help", no_argument, NULL, 'h'},
+		{"long", no_argument, NULL, 'l'},
+		{0},
+};
+
 int
 main(int argc, char *argv[]) {
 	bool has_listed = false;
@@ -262,7 +272,7 @@ main(int argc, char *argv[]) {
 	struct SqshArchive *archive;
 	uint64_t offset = 0;
 
-	while ((opt = getopt(argc, argv, "o:vrhl")) != -1) {
+	while ((opt = getopt_long(argc, argv, opts, long_opts, NULL)) != -1) {
 		switch (opt) {
 		case 'o':
 			offset = strtoull(optarg, NULL, 0);

--- a/tools/src/stat.c
+++ b/tools/src/stat.c
@@ -319,6 +319,14 @@ stat_file(struct SqshArchive *archive, const char *path) {
 	return rv;
 }
 
+static const char opts[] = "o:vh";
+static const struct option long_opts[] = {
+		{"offset", required_argument, NULL, 'o'},
+		{"version", no_argument, NULL, 'v'},
+		{"help", no_argument, NULL, 'h'},
+		{0},
+};
+
 int
 main(int argc, char *argv[]) {
 	int rv = 0;
@@ -327,7 +335,7 @@ main(int argc, char *argv[]) {
 	struct SqshArchive *archive;
 	uint64_t offset = 0;
 
-	while ((opt = getopt(argc, argv, "o:vh")) != -1) {
+	while ((opt = getopt_long(argc, argv, opts, long_opts, NULL)) != -1) {
 		switch (opt) {
 		case 'o':
 			offset = strtoull(optarg, NULL, 0);

--- a/tools/src/unpack.c
+++ b/tools/src/unpack.c
@@ -327,6 +327,16 @@ out:
 	return rv;
 }
 
+static const char opts[] = "co:vVh";
+static const struct option long_opts[] = {
+		{"chown", no_argument, NULL, 'c'},
+		{"offset", required_argument, NULL, 'o'},
+		{"version", no_argument, NULL, 'v'},
+		{"verbose", no_argument, NULL, 'V'},
+		{"help", no_argument, NULL, 'h'},
+		{0},
+};
+
 int
 main(int argc, char *argv[]) {
 	int rv = 0;
@@ -339,7 +349,7 @@ main(int argc, char *argv[]) {
 	struct SqshFile *file = NULL;
 	uint64_t offset = 0;
 
-	while ((opt = getopt(argc, argv, "co:vVh")) != -1) {
+	while ((opt = getopt_long(argc, argv, opts, long_opts, NULL)) != -1) {
 		switch (opt) {
 		case 'c':
 			do_chown = true;

--- a/tools/src/xattr.c
+++ b/tools/src/xattr.c
@@ -103,6 +103,14 @@ out:
 	return rv;
 }
 
+static const char opts[] = "o:vh";
+static const struct option long_opts[] = {
+		{"offset", required_argument, NULL, 'o'},
+		{"version", no_argument, NULL, 'v'},
+		{"help", no_argument, NULL, 'h'},
+		{0},
+};
+
 int
 main(int argc, char *argv[]) {
 	int rv = 0;
@@ -111,7 +119,7 @@ main(int argc, char *argv[]) {
 	struct SqshArchive *archive;
 	uint64_t offset = 0;
 
-	while ((opt = getopt(argc, argv, "o:vh")) != -1) {
+	while ((opt = getopt_long(argc, argv, opts, long_opts, NULL)) != -1) {
 		switch (opt) {
 		case 'o':
 			offset = strtoull(optarg, NULL, 0);


### PR DESCRIPTION
This change introduces initial longopts support for the command line tools. It also updates the man pages to reflect the new options.