### PR TITLE
test: fix build with muon.

### DIFF
--- a/test/libsqsh/meson.build
+++ b/test/libsqsh/meson.build
@@ -65,11 +65,12 @@ squashfs = custom_target(
     command: [integration_create, '', '@OUTPUT@', '@PRIVATE_DIR@'],
 )
 
+f2h = files('f2h.sh')
 squashfs_h = custom_target(
     'squashfs_image.c',
     input: squashfs,
     output: 'squashfs_image.c',
-    command: ['./f2h.sh', 'squashfs_image', '@INPUT@', '@OUTPUT@'],
+    command: [f2h, 'squashfs_image', '@INPUT@', '@OUTPUT@'],
 )
 sqsh_extra_source += {
     'integration.c': squashfs_h,


### PR DESCRIPTION
This change calls the f2h.sh script with an absolute path. This fixes the build with muon with uses the build directory as the current working directory for calling scripts.