### PR TITLE
extract: lookup extractor implementation once

### DIFF
--- a/libsqsh/include/sqsh_extract_private.h
+++ b/libsqsh/include/sqsh_extract_private.h
@@ -125,7 +125,7 @@ sqsh__extractor_impl_from_id(int id);
  */
 SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__extractor_init(
 		struct SqshExtractor *extractor, struct CxBuffer *buffer,
-		int algorithm_id, size_t block_size);
+		const struct SqshExtractorImpl *impl, size_t block_size);
 
 /**
  * @internal
@@ -176,7 +176,7 @@ struct SqshExtractManager {
 	 * @privatesection
 	 */
 	struct CxRcHashMap hash_map;
-	unsigned int compression_id;
+	const struct SqshExtractorImpl *extractor_impl;
 	uint32_t block_size;
 	struct SqshMapManager *map_manager;
 	struct CxLru lru;

--- a/libsqsh/src/extract/extractor.c
+++ b/libsqsh/src/extract/extractor.c
@@ -63,10 +63,8 @@ sqsh__extractor_impl_from_id(int id) {
 int
 sqsh__extractor_init(
 		struct SqshExtractor *extractor, struct CxBuffer *buffer,
-		int algorithm_id, size_t block_size) {
+		const struct SqshExtractorImpl *impl, size_t block_size) {
 	int rv = 0;
-	const struct SqshExtractorImpl *impl =
-			sqsh__extractor_impl_from_id(algorithm_id);
 	if (impl == NULL) {
 		rv = -SQSH_ERROR_COMPRESSION_UNSUPPORTED;
 		goto out;


### PR DESCRIPTION
Instead of looking up the extractor implementation every time a new extractor is initialized, lookup the implementation once in the extract manager.