### PR TITLE
easy: add a function to list directory paths

### DIFF
--- a/include/sqsh_easy.h
+++ b/include/sqsh_easy.h
@@ -119,7 +119,7 @@ sqsh_easy_file_mtime(struct SqshArchive *archive, const char *path, int *err);
  */
 
 /**
- * @brief retrieves the contents of a directory.
+ * @brief retrieves the contents of a directory as a list of file names
  *
  * The returned list needs to be released with `free()`.
  *
@@ -130,6 +130,20 @@ sqsh_easy_file_mtime(struct SqshArchive *archive, const char *path, int *err);
  * @return A list of files and directories on success, NULL on error.
  */
 char **sqsh_easy_directory_list(
+		struct SqshArchive *archive, const char *path, int *err);
+
+/**
+ * @brief retrieves the contents of a directory as a list of file paths
+ *
+ * The returned list needs to be released with `free()`.
+ *
+ * @param[in] archive  The sqsh archive context.
+ * @param[in] path     The path the file or directory.
+ * @param[out] err     Pointer to an int where the error code will be stored.
+ *
+ * @return A list of files and directories on success, NULL on error.
+ */
+char **sqsh_easy_directory_list_path(
 		struct SqshArchive *archive, const char *path, int *err);
 
 /***************************************

--- a/libsqsh/src/easy/directory.c
+++ b/libsqsh/src/easy/directory.c
@@ -31,7 +31,6 @@
  * @file         file.c
  */
 
-#include <stdint.h>
 #define _DEFAULT_SOURCE
 
 #include <sqsh_easy.h>
@@ -45,6 +44,88 @@
 #include <sqsh_error.h>
 #include <sqsh_file_private.h>
 #include <sqsh_tree_private.h>
+
+struct DirectoryIterator {
+	struct SqshDirectoryIterator dir;
+	const char *path;
+	size_t path_size;
+	struct CxBuffer value;
+};
+
+static int
+directory_path_collector_next(
+		void *iterator, const char **value, size_t *size) {
+	struct DirectoryIterator *it = iterator;
+	int rv = 0;
+	if (sqsh_directory_iterator_next(&it->dir, &rv)) {
+		cx_buffer_drain(&it->value);
+		rv = cx_buffer_append(
+				&it->value, (const uint8_t *)it->path, it->path_size);
+		if (rv < 0) {
+			goto out;
+		}
+		rv = cx_buffer_append(&it->value, (const uint8_t *)"/", 1);
+		if (rv < 0) {
+			goto out;
+		}
+		rv = cx_buffer_append(
+				&it->value,
+				(const uint8_t *)sqsh_directory_iterator_name(&it->dir),
+				(size_t)sqsh_directory_iterator_name_size(&it->dir));
+		if (rv < 0) {
+			goto out;
+		}
+		*value = (const char *)cx_buffer_data(&it->value);
+		*size = cx_buffer_size(&it->value);
+	}
+out:
+	return rv;
+}
+
+char **
+sqsh_easy_directory_list_path(
+		struct SqshArchive *archive, const char *path, int *err) {
+	int rv = 0;
+	struct SqshFile *file = NULL;
+	struct DirectoryIterator iterator = {0};
+	char **list = NULL;
+
+	file = sqsh_open(archive, path, &rv);
+	if (rv < 0) {
+		goto out;
+	}
+
+	rv = sqsh__directory_iterator_init(&iterator.dir, file);
+	if (rv < 0) {
+		goto out;
+	}
+
+	rv = cx_buffer_init(&iterator.value);
+	if (rv < 0) {
+		goto out;
+	}
+
+	iterator.path = path;
+	iterator.path_size = strlen(path);
+	while (iterator.path_size > 0 &&
+		   iterator.path[iterator.path_size - 1] == '/') {
+		iterator.path_size--;
+	}
+
+	rv = cx_collect(&list, directory_path_collector_next, &iterator.dir);
+	if (rv < 0) {
+		goto out;
+	}
+
+out:
+	cx_buffer_cleanup(&iterator.value);
+	sqsh__directory_iterator_cleanup(&iterator.dir);
+	sqsh_close(file);
+	if (err) {
+		*err = rv;
+	}
+	return list;
+}
 
 static int
 directory_collector_next(void *iterator, const char **value, size_t *size) {


### PR DESCRIPTION
This change adds `sqsh_easy_directory_list_path()`, a function to list the contents of a directory as a list of file paths. This enables the user to get a list of paths that can be directly passed to other easy functions like `sqsh_easy_file_content()`.

This change also adds a test for the new function.